### PR TITLE
[LEAD] header copy + mobile density polish

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -7,6 +7,8 @@
 - [LEAD] 좌측 사이드바 sticky 래핑 적용: 메인 스크롤과 분리된 내부 스크롤 유지(MainLayout/CategorySidebar)
 - [LEAD] UserTrustBadge 공통 컴포넌트 추가 + PostCard/Detail/Profile/Answer/Comment/추천·팔로잉에서 인증 배지 위치 통일(닉네임 옆)
 - [LEAD] Leaderboard/인증 신청 미리보기의 신뢰 배지 표시를 UserTrustBadge로 통일(툴팁/패딩 일관화)
+- [LEAD] 헤더 브랜드 문구를 Tooltip 대신 로고 옆 텍스트로 상시 노출
+- [LEAD] 모바일 헤더/카드 밀도 개선: 로고 문구 line-clamp, 인증 응답 라벨 `+N` 축약, 태그 영역 높이 제한, 추천 섹션 헤더 높이 고정
 - [LEAD] 모바일 홈 필터(인기/최신) 알약 투명도 미세 조정
 - [FE] 헤더 우측 액션 순서 변경(언어 스위치 → 알림) + 공유 CTA(ko) 문구 업데이트 + 사이드바 피드백 라벨을 “Feedback”으로 고정(텍스트 축소/아이콘 들여쓰기)
 - [FE] PostCard 모바일 해결/미해결 아이콘 shrink-0 보강 + PostDetail 답글/댓글 렌더 블록 괄호 정리로 lint 파서 오류 해소

--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -190,6 +190,43 @@
   - src/app/[lang]/(main)/leaderboard/LeaderboardClient.tsx
   - src/app/[lang]/(main)/verification/request/VerificationRequestClient.tsx
 
+#### (2025-12-19) [LEAD] 헤더 브랜드 문구 노출 방식 변경 (P0)
+
+- 플랜(체크리스트)
+  - [x] 브랜드 소개 문구를 Tooltip 대신 로고 옆 텍스트로 고정 노출
+- 현황 분석(코드 기준)
+  - 로고에 Tooltip이 걸려 있어 문구가 접근성/가시성 측면에서 약함
+- 변경 내용(why/what)
+  - why: 브랜드 메시지를 상시 노출해 일관된 정체성 전달
+  - what: Logo 우측에 `brandIntro` 텍스트를 배치하고 Tooltip 제거
+- 검증
+  - [x] npm run lint
+  - [x] SKIP_SITEMAP_DB=true npm run build
+- 변경 파일
+  - src/components/organisms/Header.tsx
+
+#### (2025-12-19) [LEAD] 모바일 헤더/카드 밀도 보강 (P0)
+
+- 플랜(체크리스트)
+  - [x] 로고 문구를 모바일에서도 노출하되 2줄/폭 제한 적용
+  - [x] 모바일 카드 인증 요약 라벨을 `+N` 숫자만 표시
+  - [x] 태그 칩 2줄 이상은 잘림 처리(모바일 높이 안정화)
+  - [x] 추천 사용자 섹션 타이틀/버튼 높이 고정(헤더 줄바꿈 방지)
+- 현황 분석(코드 기준)
+  - 로고 문구가 모바일에서 숨김 처리되어 브랜드 메시지가 보이지 않음
+  - 인증 응답 라벨에 텍스트가 길게 붙어 카드 하단 높이가 불안정
+  - 태그 칩이 여러 줄로 늘어나 카드 높이가 커짐
+- 변경 내용(why/what)
+  - why: 모바일 헤더/카드 밀도 확보 및 레이아웃 흔들림 제거
+  - what: 로고 문구는 line-clamp 적용, 인증 요약은 숫자만, 태그는 모바일 높이 제한, 추천 섹션 제목/버튼은 고정 높이
+- 검증
+  - [x] npm run lint
+  - [x] SKIP_SITEMAP_DB=true npm run build
+- 변경 파일
+  - src/components/organisms/Header.tsx
+  - src/components/molecules/cards/PostCard.tsx
+  - src/components/organisms/RecommendedUsersSection.tsx
+
 #### (2025-12-18) [LEAD] 컴포넌트 폴더 구조 정리: molecules/cards 분리 (P0)
 
 - 플랜(체크리스트)

--- a/src/components/molecules/cards/PostCard.tsx
+++ b/src/components/molecules/cards/PostCard.tsx
@@ -105,12 +105,7 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
   const responseNoun = isQuestion
     ? (locale === 'en' ? 'answers' : tCommon.answer || '답변')
     : (locale === 'en' ? 'comments' : tCommon.comment || '댓글');
-  const responseNounCompact = locale === 'vi'
-    ? (isQuestion ? 'trả lời' : 'bình luận')
-    : responseNoun;
-  const certifiedCompactLabel = certifiedCount > 0
-    ? `+${certifiedCount} ${responseNounCompact}`
-    : '';
+  const certifiedCompactLabel = certifiedCount > 0 ? `+${certifiedCount}` : '';
   const certifiedSummaryLabel = certifiedCount > 0
     ? (otherCount > 0
       ? (tPost.certifiedResponderSummary
@@ -579,7 +574,7 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
       </div>
 
       {tagChips.length > 0 ? (
-        <div className="mt-2 flex flex-wrap items-center gap-1.5 md:flex-nowrap md:overflow-x-auto md:scrollbar-hide md:pr-2">
+        <div className="mt-2 flex flex-wrap items-center gap-1.5 max-h-[48px] overflow-hidden sm:max-h-none md:flex-nowrap md:overflow-x-auto md:scrollbar-hide md:pr-2">
           {tagChips.map((tag) => {
             const isCategoryTag = !!categoryLabel && tag === categoryLabel;
             const isSubcategoryTag = !!subcategoryLabel && tag === subcategoryLabel;

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -7,7 +7,6 @@ import { useParams } from 'next/navigation';
 import { Bell, Menu, X } from 'lucide-react';
 import Logo from '@/components/atoms/Logo';
 import Button from '@/components/atoms/Button';
-import Tooltip from '@/components/atoms/Tooltip';
 import UserProfile from '@/components/molecules/user/UserProfile';
 import LanguageSwitcher from '@/components/atoms/LanguageSwitcher';
 import { useSession, signOut } from 'next-auth/react';
@@ -151,11 +150,12 @@ export default function Header({ isMobileMenuOpen, setIsMobileMenuOpen, showBack
             </button>
           )}
           <div className="scale-90 sm:scale-100 origin-left">
-            <Tooltip content={tTooltip.brandIntro || brandIntroFallback} position="below" className="vk-tooltip-brand">
-              <div aria-label={tTooltip.brandIntro || brandIntroFallback}>
-                <Logo />
-              </div>
-            </Tooltip>
+            <div className="flex items-center gap-2 min-w-0">
+              <Logo />
+              <span className="inline-block max-w-[90px] sm:max-w-[160px] text-[9px] sm:text-[11px] text-gray-500 dark:text-gray-400 leading-tight line-clamp-2">
+                {tTooltip.brandIntro || brandIntroFallback}
+              </span>
+            </div>
           </div>
         </div>
 

--- a/src/components/organisms/RecommendedUsersSection.tsx
+++ b/src/components/organisms/RecommendedUsersSection.tsx
@@ -241,11 +241,11 @@ export default function RecommendedUsersSection({
 
   return (
     <div className={`rounded-xl border border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-900 ${compact ? 'p-3' : 'p-4'}`}>
-      <div className="flex items-center justify-between mb-3">
-        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100">
+      <div className="flex items-center justify-between gap-2 mb-3 min-h-[32px]">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate min-w-0 flex-1">
           {title}
         </h3>
-        <div className="flex items-center gap-1">
+        <div className="flex items-center gap-1 shrink-0">
           <button
             type="button"
             onClick={() => scrollCarousel(-1)}


### PR DESCRIPTION
@codex please review

- why: 브랜드 메시지 가시성 개선 + 모바일 카드 밀도 안정화
- what: Header 로고 문구 상시 노출/line-clamp, PostCard 인증 요약 축약, 추천 섹션 헤더 높이 고정 + 문서 기록
- test: npm run lint
- test: SKIP_SITEMAP_DB=true npm run build
