### PR TITLE
[LEAD] rescue: onboarding/profile/new post + header/sidebar

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -1,20 +1,39 @@
-# VietHub (Viet K-Connect) 프로젝트 인수인계 문서
+# VietHub (Viet K-Connect) 프로젝트 문서
 
 ---
 
 ## 최근 주요 변경 사항
 
+- [FE] Header signup CTA를 “바로 시작하기” 계열로 정리 + 공유하기 CTA 설명 문구 업데이트
+- [FE] 온보딩 가이드/FAQ locale fallback 맵 정리 + 글쓰기 기본 태그 fallback locale 분리
+- [FE] 알림/피드백/프로필 편집/에디터 i18n fallback 보강(링크 모달/오류 메시지 포함)
+- [FE] 홈/프로필 메타데이터 locale fallback 분리 + Vercel/CI 빌드 환경에서 DATABASE_URL 누락 시 DB 초기화 프록시 허용
+- [FE] 온보딩 화면 locale fallback 보강(라벨/저장 오류 메시지)
+- [FE] 인증 신청 화면 라벨/상태/토스트 locale fallback 보강(ko/en/vi)
+- [FE] 인증 신청 내역 화면 라벨/혜택 안내 locale fallback 보강(ko/en/vi)
+- [FE] 글쓰기 화면 라벨/검증/버튼 locale fallback 보강(ko/en/vi)
+- [FE] Sidebar/공지 배너/숏폼 리스트 locale fallback 보강(ko/en/vi)
+- [FE] 글쓰기 페이지 metadata title/description locale fallback 보강(ko/en/vi)
+- [FE] 글쓰기 템플릿 라벨/placeholder locale fallback 보강(ko/en/vi)
+- [FE] 홈/검색/알림/피드백 metadata locale fallback 보강(ko/en/vi)
+- [FE] CategorySidebar/글쓰기 카테고리 라벨 locale fallback 보강(툴팁/구독 버튼 포함)
+- [FE] PostCard 모바일 신뢰 배지 라벨에 truncate 적용(vi 길이 이슈 대응)
+- [FE] 빌드 단계에서 DATABASE_URL 누락 시 DB 초기화 스텁으로 전환해 Vercel 빌드 크래시 방지(런타임은 환경변수 필요)
+- [WEB] 게시글 상세 공유 CTA 확장: 공유 블록 추가 + Share 라벨 정합화, 소셜 로그인 범위 Google only로 명확화(Facebook 제외)
+- [WEB] 피드백 페이지 설문형 UI 전환: 만족도 선택 + 개선요청/버그 상세 입력, 요약/이메일 입력 제거, 제출 제목 자동 생성
+- [BE] 피드백/검색 키워드/리더보드·점수/구독 알림 설정 API 및 UGC allowlist·뉴스 노출 기간·신고 액션 확장 반영(마이그레이션 0029/0030/0031/0032 필요)
 - [LEAD] 좌측 사이드바 sticky 래핑 적용: 메인 스크롤과 분리된 내부 스크롤 유지(MainLayout/CategorySidebar)
 - [LEAD] UserTrustBadge 공통 컴포넌트 추가 + PostCard/Detail/Profile/Answer/Comment/추천·팔로잉에서 인증 배지 위치 통일(닉네임 옆)
-- [LEAD] Leaderboard/인증 신청 미리보기의 신뢰 배지 표시를 UserTrustBadge로 통일(툴팁/패딩 일관화)
-- [LEAD] 헤더 브랜드 문구를 Tooltip 대신 로고 옆 텍스트로 상시 노출
-- [LEAD] 모바일 헤더/카드 밀도 개선: 로고 문구 line-clamp, 인증 응답 라벨 `+N` 축약, 태그 영역 높이 제한, 추천 섹션 헤더 높이 고정
 - [LEAD] 모바일 홈 필터(인기/최신) 알약 투명도 미세 조정
 - [FE] 헤더 우측 액션 순서 변경(언어 스위치 → 알림) + 공유 CTA(ko) 문구 업데이트 + 사이드바 피드백 라벨을 “Feedback”으로 고정(텍스트 축소/아이콘 들여쓰기)
 - [FE] PostCard 모바일 해결/미해결 아이콘 shrink-0 보강 + PostDetail 답글/댓글 렌더 블록 괄호 정리로 lint 파서 오류 해소
 - [FE] PostDetail/Search/ProfileEdit 툴팁·카테고리 locale fallback 보강(미지정/익명/툴팁 aria-label 정리)
 - [FE] PostCard 인증 응답 요약 라벨 모바일 flex-wrap 보강(vi 줄바꿈 대응)
-- [FE] 피드 PostCard에 공식/검수 답변 배지 표시 + posts/trending/users posts/bookmarks API에 공식/검수 카운트 추가
+- [FE] PostCard 공식/검수 답변 배지 노출 + 게시글 리스트/프로필/북마크/트렌딩 API에 공식·검수 카운트 추가
+- [FE] PostDetail report/경고/공유 라벨 locale fallback 통일 + PostCard 공식/검수 배지 모바일 텍스트 축소
+- [FE] Search i18n fallback 통일(placeholder/필터/페이지네이션/자동완성 라벨) + CategorySidebar 구독 섹션 locale fallback 보강
+- [FE] PostDetail SSR 메타/author fallback locale 기준으로 정리
+- [FE] PostList/추천/모달/리더보드/구독 설정 unknown fallback 공통화(anonymous/uncategorized)
 - [WEB] 온보딩 가이드 추가: Onboarding 화면에 첫 질문/첫 답변/카테고리 탐색 카드 + 툴팁 + FAQ 섹션 구성
 - [WEB] 검색 UX 보강: 검색 입력 자동완성 드롭다운 + `/api/search/keywords` 기반 추천 키워드 칩 노출
 - [WEB] 리더보드 UI/IA 추가: `/[lang]/leaderboard` SSR + HydrationBoundary, Top3 강조 카드/전체 랭킹 리스트/페이지네이션 구성
@@ -1101,6 +1120,33 @@ export async function GET(request: NextRequest) {
 
 ---
 
+### Codex CLI 스킬 프롬프트 (GitHub PR/CI)
+
+- 스킬 호출: 프롬프트에 `$<skill-name>`을 포함해 스킬을 강제 사용합니다(가능하면 상단에 배치).
+- 스킬 설치 후 인식: Codex는 시작 시 스킬을 로드하므로, 설치 직후에는 **Codex CLI를 종료 후 다시 실행**해야 합니다.
+
+#### PR CI 깨짐 분석/수정: `gh-fix-ci`
+```
+$gh-fix-ci
+
+repo: .
+pr: <PR 번호 또는 URL> (없으면 현재 브랜치 PR 자동 탐지)
+
+목표: GitHub Actions 실패 원인 요약 → 수정 플랜 작성 → (승인 후) 코드 수정
+주의: gh 인증이 안 되어 있으면 `oai_gh` 후 `gh auth status`부터 진행
+```
+
+#### PR 리뷰 코멘트 대응: `gh-address-comments`
+```
+$gh-address-comments
+
+repo: .
+pr: <PR 번호 또는 URL> (없으면 현재 브랜치 PR 자동 탐지)
+
+목표: 리뷰 코멘트를 항목별로 처리(수정 반영 + 답글)하고 남은 액션 정리
+주의: gh 인증이 안 되어 있으면 `oai_gh` 후 `gh auth status`부터 진행
+```
+
 ### 신규 기능 개발 프롬프트
 
 #### 기본 템플릿
@@ -1497,3 +1543,14 @@ Post 관련 타입을 정리해줘.
 **궁금한 점이 있으면 코드를 직접 살펴보세요. 파일 이름과 폴더 구조가 직관적이라 찾기 쉬울 거예요.**
 
 작성일: 2025년 12월
+
+---
+
+## 최근 브랜치/워킹트리 현황 메모 (2025-12-19)
+
+- `/Users/bk/Desktop/VKC-2-`
+  - 브랜치: `codex-lead-refactor` (PR #9는 원격 main에 머지됨). 로컬 `main`은 `origin/main` 최신 커밋(merge #9) 반영 필요.
+  - 미커밋 변경: `HANDOVER.md`, `docs/EXECUTION_PLAN.md`, `src/components/molecules/cards/PostCard.tsx`, `src/components/organisms/Header.tsx`, `src/components/organisms/RecommendedUsersSection.tsx`.
+- `/Users/bk/Desktop/viet-kconnect-renew-nextjs-main 2`
+  - 브랜치: `codex-subscriptions` (dirty). 대량 수정/신규 파일 존재 → 백업 전용, 선별 이관 전까지 커밋 금지.
+- 머지 상태: PR #6/#7/#8/#9는 원격 `main`에 머지 완료. 로컬 워크트리는 `git pull origin main`으로 동기화 필요.

--- a/src/app/[lang]/(main)/notifications/NotificationsClient.tsx
+++ b/src/app/[lang]/(main)/notifications/NotificationsClient.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useRouter } from 'nextjs-toploader/app';
 import Image from 'next/image';
 import { Bell, CheckCircle, MessageCircle, MessageSquare, Award, Settings, UserPlus, CheckCheck, Trash2 } from 'lucide-react';
@@ -39,6 +39,81 @@ export default function NotificationsClient({ locale, translations }: Notificati
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
 
   const t = (translations?.notifications || {}) as Record<string, string>;
+  const copy = useMemo(() => {
+    const isVi = locale === 'vi';
+    const isEn = locale === 'en';
+    const fallback = {
+      title: isVi ? 'Thông báo' : isEn ? 'Notifications' : '알림',
+      subtitle: isVi ? 'Kiểm tra cập nhật mới nhất' : isEn ? 'Check your latest updates' : '새로운 소식을 확인하세요',
+      unreadCount: isVi ? '{count} thông báo chưa đọc' : isEn ? '{count} unread notifications' : '{count}개의 읽지 않은 알림',
+      markAllRead: isVi ? 'Đánh dấu đã đọc' : isEn ? 'Mark all read' : '모두 읽음',
+      settings: isVi ? 'Cài đặt' : isEn ? 'Settings' : '설정',
+      noNotifications: isVi ? 'Không có thông báo' : isEn ? 'No notifications' : '알림이 없습니다',
+      noNotificationsDesc: isVi
+        ? 'Thông báo mới sẽ hiển thị ở đây'
+        : isEn
+          ? 'New notifications will appear here'
+          : '새로운 알림이 오면 여기에 표시됩니다',
+      noFilteredNotifications: isVi ? 'Không có thông báo {filter}' : isEn ? 'No {filter} notifications' : '{filter} 알림이 없습니다',
+      viewAll: isVi ? 'Xem tất cả thông báo' : isEn ? 'View All Notifications' : '전체 알림 보기',
+      post: isVi ? 'Bài viết' : isEn ? 'Post' : '게시글',
+      tipTitle: isVi ? 'Mẹo thông báo' : isEn ? 'Notification Tips' : '알림 설정 팁',
+      tip1: isVi
+        ? 'Bạn có thể chọn nhận thông báo trong cài đặt hồ sơ'
+        : isEn
+          ? 'You can selectively receive notifications in profile settings'
+          : '프로필 설정에서 원하는 알림만 선택적으로 받을 수 있습니다',
+      tip2: isVi
+        ? 'Bạn có thể quản lý riêng thông báo trả lời, bình luận, phản hồi và chấp nhận'
+        : isEn
+          ? 'Manage answer, comment, reply, and adoption notifications separately'
+          : '답변, 댓글, 대댓글, 채택 알림을 각각 관리할 수 있습니다',
+      tip3: isVi
+        ? 'Tắt tất cả thông báo sẽ tạm dừng mọi thông báo'
+        : isEn
+          ? 'Turning off all notifications will pause all notifications temporarily'
+          : '전체 알림을 끄면 모든 알림이 일시적으로 중단됩니다',
+      tip4: isVi
+        ? 'Kiểm tra cài đặt thông báo để không bỏ lỡ cập nhật quan trọng'
+        : isEn
+          ? 'Check your notification settings to not miss important updates'
+          : '중요한 알림을 놓치지 않도록 알림 설정을 확인하세요',
+      filters: {
+        all: isVi ? 'Tất cả' : isEn ? 'All' : '전체',
+        answer: isVi ? 'Câu trả lời' : isEn ? 'Answer' : '답변',
+        comment: isVi ? 'Bình luận' : isEn ? 'Comment' : '댓글',
+        reply: isVi ? 'Phản hồi' : isEn ? 'Reply' : '대댓글',
+        adoption: isVi ? 'Chấp nhận' : isEn ? 'Adoption' : '채택',
+        follow: isVi ? 'Theo dõi' : isEn ? 'Follow' : '팔로우',
+      },
+    };
+
+    return {
+      title: t.title || fallback.title,
+      subtitle: t.subtitle || fallback.subtitle,
+      unreadCount: t.unreadCount || fallback.unreadCount,
+      markAllRead: t.markAllRead || fallback.markAllRead,
+      settings: t.settings || fallback.settings,
+      noNotifications: t.noNotifications || fallback.noNotifications,
+      noNotificationsDesc: t.noNotificationsDesc || fallback.noNotificationsDesc,
+      noFilteredNotifications: t.noFilteredNotifications || fallback.noFilteredNotifications,
+      viewAll: t.viewAll || fallback.viewAll,
+      post: t.post || fallback.post,
+      tipTitle: t.tipTitle || fallback.tipTitle,
+      tip1: t.tip1 || fallback.tip1,
+      tip2: t.tip2 || fallback.tip2,
+      tip3: t.tip3 || fallback.tip3,
+      tip4: t.tip4 || fallback.tip4,
+      filters: {
+        all: t.all || fallback.filters.all,
+        answer: t.answer || fallback.filters.answer,
+        comment: t.comment || fallback.filters.comment,
+        reply: t.reply || fallback.filters.reply,
+        adoption: t.adoption || fallback.filters.adoption,
+        follow: t.follow || fallback.filters.follow,
+      },
+    };
+  }, [locale, t]);
 
   const { data, isLoading, refetch } = useNotifications(
     { limit: 50 },
@@ -102,7 +177,7 @@ export default function NotificationsClient({ locale, translations }: Notificati
   };
 
   const getFilterLabel = (type: string) => {
-    return t[type] || type;
+    return copy.filters[type as keyof typeof copy.filters] || type;
   };
 
   useEffect(() => {
@@ -136,11 +211,11 @@ export default function NotificationsClient({ locale, translations }: Notificati
                   <Bell className="w-6 h-6 text-white" />
                 </div>
                 <div>
-                  <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{t.title || 'Notifications'}</h1>
+                  <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{copy.title}</h1>
                   <p className="text-sm text-gray-500 dark:text-gray-400">
-                    {unreadCount > 0 
-                      ? (t.unreadCount || '{count}개의 읽지 않은 알림').replace('{count}', unreadCount.toString())
-                      : t.subtitle || 'Check your latest updates'}
+                    {unreadCount > 0
+                      ? copy.unreadCount.replace('{count}', unreadCount.toString())
+                      : copy.subtitle}
                   </p>
                 </div>
               </div>
@@ -153,7 +228,7 @@ export default function NotificationsClient({ locale, translations }: Notificati
                     disabled={markAllAsRead.isPending}
                   >
                     <CheckCheck className="w-4 h-4" />
-                    <span className="text-sm font-medium hidden sm:inline">{t.markAllRead || 'Mark all read'}</span>
+                    <span className="text-sm font-medium hidden sm:inline">{copy.markAllRead}</span>
                   </Button>
                 )}
                 <button
@@ -161,7 +236,7 @@ export default function NotificationsClient({ locale, translations }: Notificati
                   className="flex items-center gap-2 px-4 py-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white border border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors"
                 >
                   <Settings className="w-4 h-4" />
-                  <span className="text-sm font-medium hidden sm:inline">{t.settings || 'Settings'}</span>
+                  <span className="text-sm font-medium hidden sm:inline">{copy.settings}</span>
                 </button>
               </div>
             </div>
@@ -194,19 +269,19 @@ export default function NotificationsClient({ locale, translations }: Notificati
               <div className="text-center py-16">
                 <Bell className="w-16 h-16 text-gray-300 dark:text-gray-600 mx-auto mb-4" />
                 <h3 className="text-lg font-semibold text-gray-900 dark:text-white mb-2">
-                  {t.noNotifications || 'No notifications'}
+                  {copy.noNotifications}
                 </h3>
                 <p className="text-sm text-gray-500 dark:text-gray-400 mb-6">
                   {filter === 'all'
-                    ? t.noNotificationsDesc || 'New notifications will appear here'
-                    : (t.noFilteredNotifications || 'No {filter} notifications').replace('{filter}', getFilterLabel(filter))}
+                    ? copy.noNotificationsDesc
+                    : copy.noFilteredNotifications.replace('{filter}', getFilterLabel(filter))}
                 </p>
                 {filter !== 'all' && (
                   <button
                     onClick={() => setFilter('all')}
                     className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-red-600 to-amber-500 text-white font-semibold rounded-lg hover:from-red-700 hover:to-amber-600 transition-all duration-300"
                   >
-                    {t.viewAll || 'View All Notifications'}
+                    {copy.viewAll}
                   </button>
                 )}
               </div>
@@ -262,7 +337,7 @@ export default function NotificationsClient({ locale, translations }: Notificati
                         </p>
                         {notification.postTitle && (
                           <p className="text-xs text-gray-500 dark:text-gray-500 truncate">
-                            {t.post || 'Post'}: {notification.postTitle}
+                            {copy.post}: {notification.postTitle}
                           </p>
                         )}
                       </div>
@@ -282,13 +357,13 @@ export default function NotificationsClient({ locale, translations }: Notificati
           {filteredNotifications.length === 0 && !isLoading && (
             <div className="mt-6 bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-800 rounded-lg p-6">
               <h3 className="text-sm font-semibold text-blue-900 dark:text-blue-300 mb-3">
-                💡 {t.tipTitle || 'Notification Tips'}
+                💡 {copy.tipTitle}
               </h3>
               <ul className="text-sm text-blue-800 dark:text-blue-300 space-y-2">
-                <li>• {t.tip1 || 'You can selectively receive notifications in profile settings'}</li>
-                <li>• {t.tip2 || 'Manage answer, comment, reply, and adoption notifications separately'}</li>
-                <li>• {t.tip3 || 'Turning off all notifications will pause all notifications temporarily'}</li>
-                <li>• {t.tip4 || 'Check your notification settings to not miss important updates'}</li>
+                <li>• {copy.tip1}</li>
+                <li>• {copy.tip2}</li>
+                <li>• {copy.tip3}</li>
+                <li>• {copy.tip4}</li>
               </ul>
             </div>
           )}

--- a/src/app/[lang]/(main)/onboarding/OnboardingClient.tsx
+++ b/src/app/[lang]/(main)/onboarding/OnboardingClient.tsx
@@ -27,82 +27,238 @@ interface OnboardingClientProps {
 export default function OnboardingClient({ lang, translations }: OnboardingClientProps) {
   const router = useRouter();
   const queryClient = useQueryClient();
-  const { data: session, status } = useSession();
+  const { status } = useSession();
   const { data: categories } = useCategories();
   const t = translations?.onboarding || {};
-  const guideCopy = useMemo(() => {
+  const uiCopy = useMemo(() => {
     if (lang === 'en') {
       return {
-        title: t.guideTitle || 'Quick start guide',
-        subtitle: t.guideSubtitle || 'Get started with your first question, answer, and category.',
-        askTitle: t.guideAskTitle || 'Ask your first question',
-        askDesc: t.guideAskDesc || 'Share your situation to get focused answers.',
-        askAction: t.guideAskAction || 'Ask a question',
-        askTooltip: t.guideAskTooltip || 'Include your visa type and goal for faster help.',
-        answerTitle: t.guideAnswerTitle || 'Leave your first answer',
-        answerDesc: t.guideAnswerDesc || 'Support others and build trust.',
-        answerAction: t.guideAnswerAction || 'Browse popular questions',
-        answerTooltip: t.guideAnswerTooltip || 'Helpful answers raise your trust score.',
-        exploreTitle: t.guideExploreTitle || 'Explore categories',
-        exploreDesc: t.guideExploreDesc || 'Find the topics you care about most.',
-        exploreAction: t.guideExploreAction || 'Explore now',
-        exploreTooltip: t.guideExploreTooltip || 'Subscribe to categories to personalize your feed.',
-        faqTitle: t.guideFaqTitle || 'FAQ',
-        faq1Q: t.guideFaq1Q || 'How can I get verified answers?',
-        faq1A: t.guideFaq1A || 'Check for Verified/Expert badges on posts and profiles.',
-        faq2Q: t.guideFaq2Q || 'Where can I manage subscriptions?',
-        faq2A: t.guideFaq2A || 'Open profile settings to manage category subscriptions.',
-        faq3Q: t.guideFaq3Q || 'How do I report incorrect info?',
-        faq3A: t.guideFaq3A || 'Use the report button on each post or answer.',
+        title: 'We\'ll tailor your feed',
+        description: 'Choose profile info to surface the categories and content you care about first.',
+        userTypeLabel: 'User type',
+        userTypeStudent: 'Student',
+        userTypeStudentDesc: 'International or exchange student',
+        userTypeWorker: 'Worker',
+        userTypeWorkerDesc: 'Employment, job change prep',
+        userTypeResident: 'Resident',
+        userTypeResidentDesc: 'Long-term stay, family',
+        koreanLevelLabel: 'Korean level',
+        visaLabel: 'Visa type',
+        interestsLabel: 'Interest categories',
+        interestsHint: 'Select up to 5.',
+        submitting: 'Saving...',
+        submit: 'Done',
+        skip: 'Skip',
+        saveSuccess: 'Personalization saved.',
+        saveError: 'Failed to save profile.',
+        defaultError: 'Failed to save.',
       };
     }
     if (lang === 'vi') {
       return {
-        title: t.guideTitle || 'Hướng dẫn nhanh',
-        subtitle: t.guideSubtitle || 'Bắt đầu với câu hỏi, câu trả lời và danh mục đầu tiên.',
-        askTitle: t.guideAskTitle || 'Đặt câu hỏi đầu tiên',
-        askDesc: t.guideAskDesc || 'Chia sẻ hoàn cảnh để nhận câu trả lời phù hợp.',
-        askAction: t.guideAskAction || 'Đặt câu hỏi',
-        askTooltip: t.guideAskTooltip || 'Thêm loại visa và mục tiêu để được hỗ trợ nhanh hơn.',
-        answerTitle: t.guideAnswerTitle || 'Trả lời câu hỏi đầu tiên',
-        answerDesc: t.guideAnswerDesc || 'Giúp cộng đồng và tăng độ tin cậy.',
-        answerAction: t.guideAnswerAction || 'Xem câu hỏi nổi bật',
-        answerTooltip: t.guideAnswerTooltip || 'Câu trả lời hữu ích giúp tăng điểm tin cậy.',
-        exploreTitle: t.guideExploreTitle || 'Khám phá danh mục',
-        exploreDesc: t.guideExploreDesc || 'Tìm chủ đề bạn quan tâm nhất.',
-        exploreAction: t.guideExploreAction || 'Khám phá ngay',
-        exploreTooltip: t.guideExploreTooltip || 'Theo dõi danh mục để cá nhân hóa bảng tin.',
-        faqTitle: t.guideFaqTitle || 'FAQ',
-        faq1Q: t.guideFaq1Q || 'Làm sao nhận câu trả lời xác minh?',
-        faq1A: t.guideFaq1A || 'Xem huy hiệu Đã xác minh/Chuyên gia ở bài viết và hồ sơ.',
-        faq2Q: t.guideFaq2Q || 'Quản lý theo dõi ở đâu?',
-        faq2A: t.guideFaq2A || 'Mở cài đặt hồ sơ để quản lý theo dõi danh mục.',
-        faq3Q: t.guideFaq3Q || 'Báo cáo thông tin sai thế nào?',
-        faq3A: t.guideFaq3A || 'Dùng nút báo cáo ở mỗi bài viết hoặc câu trả lời.',
+        title: 'Chuẩn bị bảng tin cho bạn',
+        description: 'Chọn thông tin hồ sơ để ưu tiên danh mục và nội dung bạn quan tâm.',
+        userTypeLabel: 'Loại người dùng',
+        userTypeStudent: 'Sinh viên',
+        userTypeStudentDesc: 'Du học sinh, sinh viên trao đổi',
+        userTypeWorker: 'Người đi làm',
+        userTypeWorkerDesc: 'Việc làm, chuyển việc',
+        userTypeResident: 'Cư dân',
+        userTypeResidentDesc: 'Cư trú dài hạn, gia đình',
+        koreanLevelLabel: 'Trình độ tiếng Hàn',
+        visaLabel: 'Loại visa',
+        interestsLabel: 'Danh mục quan tâm',
+        interestsHint: 'Chọn tối đa 5 mục.',
+        submitting: 'Đang lưu...',
+        submit: 'Hoàn tất',
+        skip: 'Bỏ qua',
+        saveSuccess: 'Đã lưu tuỳ chỉnh cá nhân.',
+        saveError: 'Không thể lưu hồ sơ.',
+        defaultError: 'Lỗi khi lưu.',
       };
     }
     return {
-      title: t.guideTitle || '빠른 시작 가이드',
-      subtitle: t.guideSubtitle || '첫 질문, 첫 답변, 카테고리 탐색을 바로 시작해보세요.',
-      askTitle: t.guideAskTitle || '첫 질문 등록',
-      askDesc: t.guideAskDesc || '상황을 공유하면 정확한 답변을 받을 수 있어요.',
-      askAction: t.guideAskAction || '질문하기',
-      askTooltip: t.guideAskTooltip || '비자 타입과 목표를 적으면 더 빠르게 도움을 받아요.',
-      answerTitle: t.guideAnswerTitle || '첫 답변 남기기',
-      answerDesc: t.guideAnswerDesc || '도움을 주고 신뢰 점수를 올려보세요.',
-      answerAction: t.guideAnswerAction || '인기 질문 보기',
-      answerTooltip: t.guideAnswerTooltip || '도움이 된 답변이 신뢰 점수에 반영됩니다.',
-      exploreTitle: t.guideExploreTitle || '카테고리 탐색',
-      exploreDesc: t.guideExploreDesc || '관심 있는 주제를 찾아 구독해보세요.',
-      exploreAction: t.guideExploreAction || '탐색하기',
-      exploreTooltip: t.guideExploreTooltip || '카테고리를 구독하면 피드가 맞춤화돼요.',
-      faqTitle: t.guideFaqTitle || '자주 묻는 질문',
-      faq1Q: t.guideFaq1Q || '검증된 답변은 어떻게 확인하나요?',
-      faq1A: t.guideFaq1A || '게시글/프로필의 인증·전문가 배지를 확인하세요.',
-      faq2Q: t.guideFaq2Q || '구독 관리는 어디서 하나요?',
-      faq2A: t.guideFaq2A || '프로필 설정에서 카테고리 구독을 관리할 수 있어요.',
-      faq3Q: t.guideFaq3Q || '잘못된 정보는 어떻게 신고하나요?',
-      faq3A: t.guideFaq3A || '게시글/답변의 신고 버튼을 눌러 주세요.',
+      title: '맞춤 피드를 준비할게요',
+      description: '프로필 정보를 선택하면 관심사에 맞춘 카테고리와 콘텐츠를 먼저 보여드려요.',
+      userTypeLabel: '사용자 유형',
+      userTypeStudent: '학생',
+      userTypeStudentDesc: '유학생, 교환학생',
+      userTypeWorker: '근로자',
+      userTypeWorkerDesc: '취업/근로/이직 준비',
+      userTypeResident: '거주자',
+      userTypeResidentDesc: '장기 거주, 가족 동반',
+      koreanLevelLabel: '한국어 수준',
+      visaLabel: '비자 유형',
+      interestsLabel: '관심 카테고리',
+      interestsHint: '최대 5개까지 선택하세요.',
+      submitting: '저장 중...',
+      submit: '완료',
+      skip: '건너뛰기',
+      saveSuccess: '맞춤 설정이 저장되었습니다.',
+      saveError: '프로필 저장에 실패했습니다.',
+      defaultError: '저장 중 오류가 발생했습니다.',
+    };
+  }, [lang]);
+  const pageTitle = t.title || uiCopy.title;
+  const pageDescription = t.description || uiCopy.description;
+  const userTypeLabel = t.userTypeLabel || uiCopy.userTypeLabel;
+  const interestsLabel = t.interestsLabel || uiCopy.interestsLabel;
+  const interestsHint = t.interestsHint || uiCopy.interestsHint;
+  const koreanLevelLabel = t.koreanLevelLabel || uiCopy.koreanLevelLabel;
+  const visaLabel = t.visaLabel || uiCopy.visaLabel;
+  const submittingLabel = t.submitting || uiCopy.submitting;
+  const submitLabel = t.submit || uiCopy.submit;
+  const saveSuccessLabel = t.successMessage || uiCopy.saveSuccess;
+  const saveErrorLabel = t.saveError || t.errorMessage || uiCopy.saveError;
+  const defaultErrorLabel = t.errorMessage || uiCopy.defaultError;
+  const userTypeOptions = useMemo(() => (
+    [
+      {
+        value: 'student',
+        label: t.userTypeStudent || uiCopy.userTypeStudent,
+        description: t.userTypeStudentDesc || uiCopy.userTypeStudentDesc,
+      },
+      {
+        value: 'worker',
+        label: t.userTypeWorker || uiCopy.userTypeWorker,
+        description: t.userTypeWorkerDesc || uiCopy.userTypeWorkerDesc,
+      },
+      {
+        value: 'resident',
+        label: t.userTypeResident || uiCopy.userTypeResident,
+        description: t.userTypeResidentDesc || uiCopy.userTypeResidentDesc,
+      },
+    ]
+  ), [t, uiCopy]);
+  const wizardCopy = useMemo(() => {
+    if (lang === 'en') {
+      return {
+        stepLabel: 'Step',
+        next: 'Next',
+        back: 'Back',
+        skip: 'Skip for now',
+        step1: 'About you',
+        step2: 'Choose interests',
+        step3: 'Optional details',
+      };
+    }
+    if (lang === 'vi') {
+      return {
+        stepLabel: 'Bước',
+        next: 'Tiếp tục',
+        back: 'Quay lại',
+        skip: 'Bỏ qua',
+        step1: 'Thông tin cơ bản',
+        step2: 'Chọn chủ đề',
+        step3: 'Thông tin thêm',
+      };
+    }
+    return {
+      stepLabel: '단계',
+      next: '다음',
+      back: '이전',
+      skip: '건너뛰기',
+      step1: '기본 정보',
+      step2: '관심 주제 선택',
+      step3: '추가 정보',
+    };
+  }, [lang]);
+  const guideCopy = useMemo(() => {
+    const guideFallbacks = {
+      en: {
+        title: 'Quick start guide',
+        subtitle: 'Get started with your first question, answer, and category.',
+        askTitle: 'Ask your first question',
+        askDesc: 'Share your situation to get focused answers.',
+        askAction: 'Ask a question',
+        askTooltip: 'Include your visa type and goal for faster help.',
+        answerTitle: 'Leave your first answer',
+        answerDesc: 'Support others and build trust.',
+        answerAction: 'Browse popular questions',
+        answerTooltip: 'Helpful answers raise your trust score.',
+        exploreTitle: 'Explore categories',
+        exploreDesc: 'Find the topics you care about most.',
+        exploreAction: 'Explore now',
+        exploreTooltip: 'Subscribe to categories to personalize your feed.',
+        faqTitle: 'FAQ',
+        faq1Q: 'How can I get verified answers?',
+        faq1A: 'Check for Verified/Expert badges on posts and profiles.',
+        faq2Q: 'Where can I manage subscriptions?',
+        faq2A: 'Open profile settings to manage category subscriptions.',
+        faq3Q: 'How do I report incorrect info?',
+        faq3A: 'Use the report button on each post or answer.',
+      },
+      vi: {
+        title: 'Hướng dẫn nhanh',
+        subtitle: 'Bắt đầu với câu hỏi, câu trả lời và danh mục đầu tiên.',
+        askTitle: 'Đặt câu hỏi đầu tiên',
+        askDesc: 'Chia sẻ hoàn cảnh để nhận câu trả lời phù hợp.',
+        askAction: 'Đặt câu hỏi',
+        askTooltip: 'Thêm loại visa và mục tiêu để được hỗ trợ nhanh hơn.',
+        answerTitle: 'Trả lời câu hỏi đầu tiên',
+        answerDesc: 'Giúp cộng đồng và tăng độ tin cậy.',
+        answerAction: 'Xem câu hỏi nổi bật',
+        answerTooltip: 'Câu trả lời hữu ích giúp tăng điểm tin cậy.',
+        exploreTitle: 'Khám phá danh mục',
+        exploreDesc: 'Tìm chủ đề bạn quan tâm nhất.',
+        exploreAction: 'Khám phá ngay',
+        exploreTooltip: 'Theo dõi danh mục để cá nhân hóa bảng tin.',
+        faqTitle: 'FAQ',
+        faq1Q: 'Làm sao nhận câu trả lời xác minh?',
+        faq1A: 'Xem huy hiệu Đã xác minh/Chuyên gia ở bài viết và hồ sơ.',
+        faq2Q: 'Quản lý theo dõi ở đâu?',
+        faq2A: 'Mở cài đặt hồ sơ để quản lý theo dõi danh mục.',
+        faq3Q: 'Báo cáo thông tin sai thế nào?',
+        faq3A: 'Dùng nút báo cáo ở mỗi bài viết hoặc câu trả lời.',
+      },
+      ko: {
+        title: '빠른 시작 가이드',
+        subtitle: '첫 질문, 첫 답변, 카테고리 탐색을 바로 시작해보세요.',
+        askTitle: '첫 질문 등록',
+        askDesc: '상황을 공유하면 정확한 답변을 받을 수 있어요.',
+        askAction: '질문하기',
+        askTooltip: '비자 타입과 목표를 적으면 더 빠르게 도움을 받아요.',
+        answerTitle: '첫 답변 남기기',
+        answerDesc: '도움을 주고 신뢰 점수를 올려보세요.',
+        answerAction: '인기 질문 보기',
+        answerTooltip: '도움이 된 답변이 신뢰 점수에 반영됩니다.',
+        exploreTitle: '카테고리 탐색',
+        exploreDesc: '관심 있는 주제를 찾아 구독해보세요.',
+        exploreAction: '탐색하기',
+        exploreTooltip: '카테고리를 구독하면 피드가 맞춤화돼요.',
+        faqTitle: '자주 묻는 질문',
+        faq1Q: '검증된 답변은 어떻게 확인하나요?',
+        faq1A: '게시글/프로필의 인증·전문가 배지를 확인하세요.',
+        faq2Q: '구독 관리는 어디서 하나요?',
+        faq2A: '프로필 설정에서 카테고리 구독을 관리할 수 있어요.',
+        faq3Q: '잘못된 정보는 어떻게 신고하나요?',
+        faq3A: '게시글/답변의 신고 버튼을 눌러 주세요.',
+      },
+    };
+    const fallback = guideFallbacks[lang as keyof typeof guideFallbacks] ?? guideFallbacks.ko;
+
+    return {
+      title: t.guideTitle || fallback.title,
+      subtitle: t.guideSubtitle || fallback.subtitle,
+      askTitle: t.guideAskTitle || fallback.askTitle,
+      askDesc: t.guideAskDesc || fallback.askDesc,
+      askAction: t.guideAskAction || fallback.askAction,
+      askTooltip: t.guideAskTooltip || fallback.askTooltip,
+      answerTitle: t.guideAnswerTitle || fallback.answerTitle,
+      answerDesc: t.guideAnswerDesc || fallback.answerDesc,
+      answerAction: t.guideAnswerAction || fallback.answerAction,
+      answerTooltip: t.guideAnswerTooltip || fallback.answerTooltip,
+      exploreTitle: t.guideExploreTitle || fallback.exploreTitle,
+      exploreDesc: t.guideExploreDesc || fallback.exploreDesc,
+      exploreAction: t.guideExploreAction || fallback.exploreAction,
+      exploreTooltip: t.guideExploreTooltip || fallback.exploreTooltip,
+      faqTitle: t.guideFaqTitle || fallback.faqTitle,
+      faq1Q: t.guideFaq1Q || fallback.faq1Q,
+      faq1A: t.guideFaq1A || fallback.faq1A,
+      faq2Q: t.guideFaq2Q || fallback.faq2Q,
+      faq2A: t.guideFaq2A || fallback.faq2A,
+      faq3Q: t.guideFaq3Q || fallback.faq3Q,
+      faq3A: t.guideFaq3A || fallback.faq3A,
     };
   }, [lang, t]);
 
@@ -112,6 +268,7 @@ export default function OnboardingClient({ lang, translations }: OnboardingClien
   const [koreanLevel, setKoreanLevel] = useState('');
   const [currentSubs, setCurrentSubs] = useState<string[]>([]);
   const [saving, setSaving] = useState(false);
+  const [currentStep, setCurrentStep] = useState(1);
 
   const slugToId = useMemo(() => {
     const map = new Map<string, string>();
@@ -147,6 +304,19 @@ export default function OnboardingClient({ lang, translations }: OnboardingClien
       explore: `/${lang}`,
     };
   }, [lang]);
+  const steps = useMemo(
+    () => [
+      { key: 'profile', label: wizardCopy.step1 },
+      { key: 'interests', label: wizardCopy.step2 },
+      { key: 'details', label: wizardCopy.step3 },
+    ],
+    [wizardCopy]
+  );
+  const canProceed = useMemo(() => {
+    if (currentStep === 1) return Boolean(userType);
+    if (currentStep === 2) return interests.length > 0;
+    return true;
+  }, [currentStep, interests.length, userType]);
 
   const saveProfile = useMutation({
     mutationFn: async () => {
@@ -164,7 +334,7 @@ export default function OnboardingClient({ lang, translations }: OnboardingClien
       });
       if (!res.ok) {
         const error = await res.json().catch(() => ({}));
-        throw new Error(error.error || '프로필 저장에 실패했습니다.');
+        throw new Error(error.error || saveErrorLabel);
       }
       return res.json();
     },
@@ -212,14 +382,10 @@ export default function OnboardingClient({ lang, translations }: OnboardingClien
         }
       }
       queryClient.invalidateQueries({ queryKey: queryKeys.categories.subscriptions() });
-      const successMessage =
-        t.successMessage ||
-        (lang === 'vi' ? 'Đã lưu tuỳ chỉnh cá nhân.' : lang === 'en' ? 'Personalization saved.' : '맞춤 설정이 저장되었습니다.');
-      toast.success(successMessage);
+      toast.success(saveSuccessLabel);
       router.push(`/${lang}`);
     } catch (err) {
-      const defaultError = lang === 'vi' ? 'Lỗi khi lưu.' : lang === 'en' ? 'Failed to save.' : '저장 중 오류가 발생했습니다.';
-      toast.error(err instanceof Error ? err.message : defaultError);
+      toast.error(err instanceof Error ? err.message : defaultErrorLabel);
     } finally {
       setSaving(false);
     }
@@ -263,15 +429,16 @@ export default function OnboardingClient({ lang, translations }: OnboardingClien
     { question: guideCopy.faq2Q, answer: guideCopy.faq2A },
     { question: guideCopy.faq3Q, answer: guideCopy.faq3A },
   ];
+  const stepIndicator = `${wizardCopy.stepLabel} ${currentStep}/${steps.length}`;
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-red-50 via-white to-white dark:from-gray-900 dark:via-gray-900 dark:to-black">
       <div className="max-w-3xl mx-auto px-4 py-12">
         <div className="bg-white dark:bg-gray-800 rounded-2xl shadow-xl border border-gray-100/80 dark:border-gray-700/60 p-8 space-y-8">
           <div className="space-y-2">
-            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{t.title || '맞춤 피드를 준비할게요'}</h1>
+            <h1 className="text-3xl font-bold text-gray-900 dark:text-white">{pageTitle}</h1>
             <p className="text-sm text-gray-600 dark:text-gray-400">
-              {t.description || '프로필 정보를 선택하면 관심사에 맞춘 카테고리와 콘텐츠를 먼저 보여드려요.'}
+              {pageDescription}
             </p>
           </div>
 
@@ -330,110 +497,68 @@ export default function OnboardingClient({ lang, translations }: OnboardingClien
           </div>
 
           <form onSubmit={handleSubmit} className="space-y-6">
-            <div className="space-y-2">
-              <label className="text-sm font-semibold text-gray-800 dark:text-gray-200">
-                {t.userTypeLabel || '사용자 유형'}
+            <div className="space-y-3 rounded-2xl border border-gray-200/70 dark:border-gray-700/60 bg-white dark:bg-gray-900 p-4">
+              <div className="flex items-center justify-between text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-[0.2em]">
+                <span>{stepIndicator}</span>
+                <span>{steps[currentStep - 1]?.label}</span>
+              </div>
+              <div className="flex items-center gap-2">
+                {steps.map((step, index) => {
+                  const isActive = currentStep === index + 1;
+                  const isCompleted = currentStep > index + 1;
+                  return (
+                    <div
+                      key={step.key}
+                      className={`flex-1 rounded-full px-3 py-1 text-center text-xs font-semibold ${
+                        isActive
+                          ? 'bg-red-600 text-white'
+                          : isCompleted
+                            ? 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-100'
+                            : 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400'
+                      }`}
+                    >
+                      {step.label}
+                    </div>
+                  );
+                })}
+              </div>
+            </div>
+
+            {currentStep === 1 && (
+              <div className="space-y-2">
+                <label className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                {userTypeLabel}
               </label>
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                {[
-                  {
-                    value: 'student',
-                    label: t.userTypeStudent || '학생',
-                    description: t.userTypeStudentDesc || '유학생, 교환학생',
-                  },
-                  {
-                    value: 'worker',
-                    label: t.userTypeWorker || '근로자',
-                    description: t.userTypeWorkerDesc || '취업/근로/이직 준비',
-                  },
-                  {
-                    value: 'resident',
-                    label: t.userTypeResident || '거주자',
-                    description: t.userTypeResidentDesc || '장기 거주, 가족 동반',
-                  },
-                ].map((type) => (
-                  <button
-                    key={type.value}
-                    type="button"
-                    onClick={() => setUserType(type.value)}
-                    className={`rounded-lg border px-4 py-3 text-left transition-all ${userType === type.value
-                        ? 'border-red-500 bg-red-50 text-red-700 dark:border-red-500 dark:bg-red-900/30 dark:text-red-100'
-                        : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-red-300'
+                  {userTypeOptions.map((type) => (
+                    <button
+                      key={type.value}
+                      type="button"
+                      onClick={() => setUserType(type.value)}
+                      className={`rounded-lg border px-4 py-3 text-left transition-all ${
+                        userType === type.value
+                          ? 'border-red-500 bg-red-50 text-red-700 dark:border-red-500 dark:bg-red-900/30 dark:text-red-100'
+                          : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-red-300'
                       }`}
-                  >
-                    <p className="font-semibold">{type.label}</p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
-                      {type.description}
-                    </p>
-                  </button>
-                ))}
+                    >
+                      <p className="font-semibold">{type.label}</p>
+                      <p className="text-xs text-gray-500 dark:text-gray-400">{type.description}</p>
+                    </button>
+                  ))}
+                </div>
               </div>
-            </div>
+            )}
 
-            <div className="space-y-2">
-              <label className="text-sm font-semibold text-gray-800 dark:text-gray-200">
-                {t.koreanLevelLabel || '한국어 수준'}
-              </label>
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
-                {KOREAN_LEVELS.map((level) => (
-                  <button
-                    key={level.value}
-                    type="button"
-                    onClick={() => setKoreanLevel(level.value)}
-                    className={`rounded-lg border px-4 py-3 text-left transition-all ${
-                      koreanLevel === level.value
-                        ? 'border-red-500 bg-red-50 text-red-700 dark:border-red-500 dark:bg-red-900/30 dark:text-red-100'
-                        : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-red-300'
-                    }`}
-                  >
-                    <p className="font-semibold">
-                      {t[`koreanLevel_${level.value}`] || level.label[lang as 'ko' | 'vi' | 'en'] || level.label.ko}
-                    </p>
-                    <p className="text-xs text-gray-500 dark:text-gray-400">
-                      {t[`koreanLevel_${level.value}_desc`] || ''}
-                    </p>
-                  </button>
-                ))}
-              </div>
-            </div>
-
-            <div className="space-y-2">
-              <label className="text-sm font-semibold text-gray-800 dark:text-gray-200">
-                {t.visaLabel || '비자 유형'}
-              </label>
-              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
-                {VISA_TYPES.map((v) => (
-                  <button
-                    key={v}
-                    type="button"
-                    onClick={() => setVisaType(v)}
-                    className={`rounded-md border px-3 py-2 text-sm transition-all ${visaType === v
-                        ? 'border-red-500 bg-red-50 text-red-700 dark:border-red-500 dark:bg-red-900/30 dark:text-red-100'
-                        : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-red-300'
-                      }`}
-                  >
-                    {v}
-                  </button>
-                ))}
-                <input
-                  type="text"
-                  value={visaType}
-                  onChange={(e) => setVisaType(e.target.value)}
-                  placeholder={t.visaOtherPlaceholder || (lang === 'vi' ? 'Nhập visa khác' : lang === 'en' ? 'Other visa' : '기타 직접 입력')}
-                  className="col-span-2 sm:col-span-4 px-3 py-2 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500"
-                />
-              </div>
-            </div>
-
-            <div className="space-y-3">
-              <label className="text-sm font-semibold text-gray-800 dark:text-gray-200">
-                {t.interestsLabel || '관심 카테고리'}
+            {currentStep === 2 && (
+              <div className="space-y-3">
+                <label className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                {interestsLabel}
               </label>
               <p className="text-xs text-gray-500 dark:text-gray-400">
-                {t.interestsHint || '최대 5개까지 선택하세요.'}
+                {interestsHint}
               </p>
-              <div className="flex flex-wrap gap-2">
-                {interestOptions.map((cat) => (
+                <div className="flex flex-wrap gap-2">
+                  {interestOptions.map((cat) => (
                     <button
                       key={cat.id}
                       type="button"
@@ -447,23 +572,105 @@ export default function OnboardingClient({ lang, translations }: OnboardingClien
                       {cat.name}
                     </button>
                   ))}
+                </div>
               </div>
-            </div>
+            )}
 
-            <div className="flex gap-3 pt-4">
-              <button
-                type="submit"
-                disabled={saving}
-                className="flex-1 px-6 py-3 bg-gradient-to-r from-red-600 to-amber-500 text-white font-semibold rounded-lg shadow-md hover:from-red-700 hover:to-amber-600 transition-all disabled:opacity-60"
-              >
-                {saving ? t.submitting || '저장 중...' : t.submit || '완료'}
-              </button>
+            {currentStep === 3 && (
+              <div className="space-y-6">
+                <div className="space-y-2">
+                  <label className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                    {koreanLevelLabel}
+                  </label>
+                  <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+                    {KOREAN_LEVELS.map((level) => (
+                      <button
+                        key={level.value}
+                        type="button"
+                        onClick={() => setKoreanLevel(level.value)}
+                        className={`rounded-lg border px-4 py-3 text-left transition-all ${
+                          koreanLevel === level.value
+                            ? 'border-red-500 bg-red-50 text-red-700 dark:border-red-500 dark:bg-red-900/30 dark:text-red-100'
+                            : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-red-300'
+                        }`}
+                      >
+                        <p className="font-semibold">
+                          {t[`koreanLevel_${level.value}`] || level.label[lang as 'ko' | 'vi' | 'en'] || level.label.ko}
+                        </p>
+                        <p className="text-xs text-gray-500 dark:text-gray-400">
+                          {t[`koreanLevel_${level.value}_desc`] || ''}
+                        </p>
+                      </button>
+                    ))}
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-semibold text-gray-800 dark:text-gray-200">
+                    {visaLabel}
+                  </label>
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                    {VISA_TYPES.map((v) => (
+                      <button
+                        key={v}
+                        type="button"
+                        onClick={() => setVisaType(v)}
+                        className={`rounded-md border px-3 py-2 text-sm transition-all ${
+                          visaType === v
+                            ? 'border-red-500 bg-red-50 text-red-700 dark:border-red-500 dark:bg-red-900/30 dark:text-red-100'
+                            : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:border-red-300'
+                        }`}
+                      >
+                        {v}
+                      </button>
+                    ))}
+                    <input
+                      type="text"
+                      value={visaType}
+                      onChange={(e) => setVisaType(e.target.value)}
+                      placeholder={t.visaOtherPlaceholder || (lang === 'vi' ? 'Nhập visa khác' : lang === 'en' ? 'Other visa' : '기타 직접 입력')}
+                      className="col-span-2 sm:col-span-4 px-3 py-2 rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-sm text-gray-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-red-500"
+                    />
+                  </div>
+                </div>
+              </div>
+            )}
+
+            <div className="flex flex-wrap gap-3 pt-4">
+              {currentStep > 1 && (
+                <button
+                  type="button"
+                  onClick={() => setCurrentStep((prev) => Math.max(1, prev - 1))}
+                  className="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-all"
+                >
+                  {wizardCopy.back}
+                </button>
+              )}
+              {currentStep < steps.length && (
+                <button
+                  type="button"
+                  onClick={() => setCurrentStep((prev) => Math.min(steps.length, prev + 1))}
+                  disabled={!canProceed}
+                  className="flex-1 px-6 py-3 bg-gradient-to-r from-red-600 to-amber-500 text-white font-semibold rounded-lg shadow-md hover:from-red-700 hover:to-amber-600 transition-all disabled:opacity-60"
+                >
+                  {wizardCopy.next}
+                </button>
+              )}
+              {currentStep === steps.length && (
+                <button
+                  type="submit"
+                  disabled={saving}
+                  className="flex-1 px-6 py-3 bg-gradient-to-r from-red-600 to-amber-500 text-white font-semibold rounded-lg shadow-md hover:from-red-700 hover:to-amber-600 transition-all disabled:opacity-60"
+                >
+                  {saving ? submittingLabel : submitLabel}
+                </button>
+              )}
               <button
                 type="button"
                 onClick={() => router.push(`/${lang}`)}
                 className="px-6 py-3 border border-gray-300 dark:border-gray-700 rounded-lg text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-all"
               >
-                {t.skip || '건너뛰기'}
+                {t.skip || wizardCopy.skip}
               </button>
             </div>
           </form>

--- a/src/app/[lang]/(main)/profile/[id]/page.tsx
+++ b/src/app/[lang]/(main)/profile/[id]/page.tsx
@@ -45,12 +45,36 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { lang, id } = await params;
   const dict = await getDictionary(lang);
   const t = (dict?.metadata?.profile || {}) as Record<string, string>;
+  const metaFallbacks = {
+    ko: {
+      notFoundTitle: '프로필을 찾을 수 없습니다',
+      notFoundDescription: '요청하신 프로필을 찾을 수 없습니다',
+      title: '{name} - 프로필 | viet kconnect',
+      description: '{name}님의 viet kconnect 커뮤니티 프로필. 게시글 {posts}개, 채택 {accepted}개, 댓글 {comments}개.',
+      siteName: 'viet kconnect',
+    },
+    en: {
+      notFoundTitle: 'Profile not found',
+      notFoundDescription: 'The requested profile could not be found',
+      title: '{name} - Profile | viet kconnect',
+      description: "{name}'s viet kconnect community profile. {posts} posts, {accepted} accepted answers, {comments} comments.",
+      siteName: 'viet kconnect',
+    },
+    vi: {
+      notFoundTitle: 'Không tìm thấy hồ sơ',
+      notFoundDescription: 'Không tìm thấy hồ sơ bạn yêu cầu',
+      title: '{name} - Hồ sơ | viet kconnect',
+      description: 'Hồ sơ cộng đồng viet kconnect của {name}. {posts} bài viết, {accepted} câu trả lời được chấp nhận, {comments} bình luận.',
+      siteName: 'viet kconnect',
+    },
+  };
+  const metaFallback = metaFallbacks[lang] ?? metaFallbacks.ko;
   const profile = await getProfileById(id);
 
   if (!profile) {
     return {
-      title: t.notFoundTitle || '프로필을 찾을 수 없습니다',
-      description: t.notFoundDescription || '요청하신 프로필을 찾을 수 없습니다',
+      title: t.notFoundTitle || metaFallback.notFoundTitle,
+      description: t.notFoundDescription || metaFallback.notFoundDescription,
     };
   }
 
@@ -64,10 +88,10 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       : avatarSrc
     : `${baseUrl}/brand-logo.png`;
 
-  const title = (t.title || '{name} - 프로필 | viet kconnect').replace('{name}', profile.displayName);
+  const title = (t.title || metaFallback.title).replace('{name}', profile.displayName);
   const description =
     profile.bio ||
-    (t.description || "{name}님의 viet kconnect 커뮤니티 프로필. 게시글 {posts}개, 채택 {accepted}개, 댓글 {comments}개.")
+    (t.description || metaFallback.description)
       .replace('{name}', profile.displayName)
       .replace('{posts}', String(profile.stats.posts))
       .replace('{accepted}', String(profile.stats.accepted))
@@ -93,7 +117,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       title,
       description,
       url: currentUrl,
-      siteName: t.siteName || 'viet kconnect',
+      siteName: t.siteName || metaFallback.siteName,
       images: [
         {
           url: ogImage,

--- a/src/app/[lang]/(main)/profile/edit/ProfileEditClient.tsx
+++ b/src/app/[lang]/(main)/profile/edit/ProfileEditClient.tsx
@@ -132,37 +132,160 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
   const avatarBlobUrlRef = useRef<string | null>(null);
 
   const t = (translations?.profileEdit || {}) as Record<string, string>;
-  const avatarChangeLabel = t.avatarChange || (lang === 'vi' ? 'Thay ảnh đại diện' : lang === 'en' ? 'Change avatar' : '프로필 사진 변경');
-  const avatarTooltipText = t.avatarTooltip || (lang === 'vi'
-    ? 'Bạn có thể dùng ảnh bất kỳ để dễ nhận diện.'
-    : lang === 'en'
-      ? 'Upload any image that helps others recognize you.'
-      : '식별 가능한 이미지를 업로드해 주세요.');
-  const nameTooltipText = t.nameTooltip || (lang === 'vi'
-    ? 'Tên này sẽ được hiển thị công khai trên hồ sơ và bài viết.'
-    : lang === 'en'
-      ? 'This name will be shown publicly on your profile and posts.'
-      : '프로필과 게시글에 공개로 표시되는 이름입니다.');
-  const bioTooltipText = t.bioTooltip || (lang === 'vi'
-    ? 'Giới thiệu ngắn giúp mọi người hiểu bạn tốt hơn.'
-    : lang === 'en'
-      ? 'A short intro helps others understand you.'
-      : '간단한 소개를 적으면 신뢰도와 소통이 좋아져요.');
-  const genderTooltipText = t.genderTooltip || (lang === 'vi'
-    ? 'Không bắt buộc. Dùng để cá nhân hóa gợi ý.'
-    : lang === 'en'
-      ? 'Optional. Used to personalize recommendations.'
-      : '선택 사항입니다. 맞춤 추천에 활용됩니다.');
-  const ageGroupTooltipText = t.ageGroupTooltip || (lang === 'vi'
-    ? 'Không bắt buộc. Dùng để cá nhân hóa gợi ý.'
-    : lang === 'en'
-      ? 'Optional. Used to personalize recommendations.'
-      : '선택 사항입니다. 맞춤 추천에 활용됩니다.');
-  const userTypeTooltipText = t.userTypeTooltip || t.statusTooltip || (lang === 'vi'
-    ? 'Không bắt buộc. Chọn loại người dùng của bạn.'
-    : lang === 'en'
-      ? 'Optional. Choose your user type.'
-      : '선택 사항입니다. 사용자 유형을 선택해 주세요.');
+  const tCommon = (translations?.common || {}) as Record<string, string>;
+  const copy = useMemo(() => {
+    const isVi = lang === 'vi';
+    const isEn = lang === 'en';
+    const selectLabel = t.genderSelect || (isVi ? 'Chọn' : isEn ? 'Select' : '선택');
+
+    return {
+      avatarChange: t.avatarChange || (isVi ? 'Thay đổi ảnh đại diện' : isEn ? 'Change profile photo' : '프로필 사진 변경'),
+      avatarTooltip:
+        t.avatarTooltip ||
+        (isVi
+          ? 'Bạn có thể dùng ảnh bất kỳ để dễ nhận diện.'
+          : isEn
+            ? 'Upload any image that helps others recognize you.'
+            : '식별 가능한 이미지를 업로드해 주세요.'),
+      nameTooltip:
+        t.nameTooltip ||
+        (isVi
+          ? 'Tên này sẽ được hiển thị công khai trên hồ sơ và bài viết.'
+          : isEn
+            ? 'This name will be shown publicly on your profile and posts.'
+            : '프로필과 게시글에 공개로 표시되는 이름입니다.'),
+      bioTooltip:
+        t.bioTooltip ||
+        (isVi
+          ? 'Giới thiệu ngắn giúp mọi người hiểu bạn tốt hơn.'
+          : isEn
+            ? 'A short intro helps others understand you.'
+            : '간단한 소개를 적으면 신뢰도와 소통이 좋아져요.'),
+      genderTooltip:
+        t.genderTooltip ||
+        (isVi
+          ? 'Không bắt buộc. Dùng để cá nhân hóa gợi ý.'
+          : isEn
+            ? 'Optional. Used to personalize recommendations.'
+            : '선택 사항입니다. 맞춤 추천에 활용됩니다.'),
+      ageGroupTooltip:
+        t.ageGroupTooltip ||
+        (isVi
+          ? 'Không bắt buộc. Dùng để cá nhân hóa gợi ý.'
+          : isEn
+            ? 'Optional. Used to personalize recommendations.'
+            : '선택 사항입니다. 맞춤 추천에 활용됩니다.'),
+      userTypeTooltip:
+        t.userTypeTooltip ||
+        t.statusTooltip ||
+        (isVi
+          ? 'Không bắt buộc. Chọn loại người dùng của bạn.'
+          : isEn
+            ? 'Optional. Choose your user type.'
+            : '선택 사항입니다. 사용자 유형을 선택해 주세요.'),
+      nameValidationError:
+        t.nameValidationError ||
+        (isVi
+          ? `Biệt danh phải từ ${DISPLAY_NAME_MIN_LENGTH}–${DISPLAY_NAME_MAX_LENGTH} ký tự.`
+          : isEn
+            ? `Nickname must be ${DISPLAY_NAME_MIN_LENGTH}–${DISPLAY_NAME_MAX_LENGTH} characters.`
+            : `닉네임은 ${DISPLAY_NAME_MIN_LENGTH}~${DISPLAY_NAME_MAX_LENGTH}자여야 합니다.`),
+      updateSuccess: t.updateSuccess || (isVi ? 'Hồ sơ đã được cập nhật.' : isEn ? 'Profile updated.' : '프로필이 업데이트되었습니다.'),
+      updateFailed: t.updateFailed || (isVi ? 'Không thể cập nhật hồ sơ.' : isEn ? 'Failed to update profile.' : '프로필 업데이트에 실패했습니다.'),
+      avatarOnlyImages: t.avatarOnlyImages || (isVi ? 'Chỉ cho phép tệp ảnh.' : isEn ? 'Only image files are allowed.' : '이미지 파일만 업로드할 수 있습니다.'),
+      avatarTooLarge: t.avatarTooLarge || (isVi ? 'Kích thước ảnh phải ≤ 20MB.' : isEn ? 'Image must be 20MB or less.' : '이미지 크기는 20MB 이하여야 합니다.'),
+      avatarUploadFailed: t.avatarUploadFailed || (isVi ? 'Tải ảnh đại diện thất bại.' : isEn ? 'Failed to upload profile photo.' : '프로필 사진 업로드에 실패했습니다.'),
+      avatarUploadSuccess: t.avatarUploadSuccess || (isVi ? 'Đã cập nhật ảnh đại diện.' : isEn ? 'Profile photo updated.' : '프로필 사진이 업데이트되었습니다.'),
+      avatarDecodeFailed:
+        t.avatarDecodeFailed ||
+        (isVi
+          ? 'Không thể xử lý ảnh. Vui lòng chọn ảnh JPG/PNG.'
+          : isEn
+            ? 'Failed to process image. Please choose a JPG/PNG.'
+            : '이미지를 처리할 수 없습니다. JPG/PNG 이미지를 선택해주세요.'),
+      avatarHeicUnsupported:
+        t.avatarHeicUnsupported ||
+        (isVi
+          ? 'Ảnh HEIC/HEIF chưa được hỗ trợ. Vui lòng chọn JPG/PNG.'
+          : isEn
+            ? 'HEIC/HEIF is not supported. Please choose a JPG/PNG.'
+            : 'HEIC/HEIF 형식은 아직 지원되지 않습니다. JPG/PNG 이미지를 선택해주세요.'),
+      backButton: t.backButton || (isVi ? 'Quay lại' : isEn ? 'Go back' : '뒤로 가기'),
+      pageTitle: t.pageTitle || (isVi ? 'Chỉnh sửa hồ sơ' : isEn ? 'Edit Profile' : '프로필 수정'),
+      profileAlt: t.profileAlt || (isVi ? 'Hồ sơ' : isEn ? 'Profile' : '프로필'),
+      nameLabel: t.nameLabel || (isVi ? 'Tên' : isEn ? 'Name' : '이름'),
+      namePlaceholder: t.namePlaceholder || (isVi ? 'Nhập tên của bạn' : isEn ? 'Enter your name' : '이름을 입력하세요'),
+      bioLabel: t.bioLabel || (isVi ? 'Giới thiệu' : isEn ? 'Bio' : '자기소개'),
+      bioPlaceholder: t.bioPlaceholder || (isVi ? 'Nhập giới thiệu về bản thân' : isEn ? 'Enter your bio' : '자기소개를 입력하세요'),
+      genderLabel: t.genderLabel || (isVi ? 'Giới tính' : isEn ? 'Gender' : '성별'),
+      selectLabel,
+      genderMale: t.genderMale || (isVi ? 'Nam' : isEn ? 'Male' : '남성'),
+      genderFemale: t.genderFemale || (isVi ? 'Nữ' : isEn ? 'Female' : '여성'),
+      genderOther: t.genderOther || (isVi ? 'Khác' : isEn ? 'Other' : '기타'),
+      ageGroupLabel: t.ageGroupLabel || (isVi ? 'Độ tuổi' : isEn ? 'Age Group' : '연령대'),
+      ageGroup10s: t.ageGroup10s || (isVi ? '10-19' : isEn ? '10s' : '10대'),
+      ageGroup20s: t.ageGroup20s || (isVi ? '20-29' : isEn ? '20s' : '20대'),
+      ageGroup30s: t.ageGroup30s || (isVi ? '30-39' : isEn ? '30s' : '30대'),
+      ageGroup40s: t.ageGroup40s || (isVi ? '40-49' : isEn ? '40s' : '40대'),
+      ageGroup50s: t.ageGroup50s || (isVi ? '50-59' : isEn ? '50s' : '50대'),
+      ageGroup60plus: t.ageGroup60plus || (isVi ? '60+' : isEn ? '60+' : '60대+'),
+      userTypeLabel: t.userTypeLabel || t.statusLabel || (isVi ? 'Trạng thái' : isEn ? 'Status' : '사용자 유형'),
+      userTypeStudent: t.userTypeStudent || t.statusStudent || (isVi ? 'Sinh viên' : isEn ? 'Student' : '학생'),
+      userTypeWorker: t.userTypeWorker || t.statusWorker || (isVi ? 'Nhân viên' : isEn ? 'Worker' : '근로자'),
+      userTypeResident: t.userTypeResident || (isVi ? 'Cư dân' : isEn ? 'Resident' : '거주자'),
+      notificationTitle: t.notificationTitle || (isVi ? 'Cài đặt thông báo' : isEn ? 'Notification Settings' : '알림 설정'),
+      notifyAll: t.notifyAll || (isVi ? 'Tất cả thông báo' : isEn ? 'All notifications' : '전체 알림'),
+      notifyAnswers: t.notifyAnswers || (isVi ? 'Thông báo câu trả lời' : isEn ? 'Answer notifications' : '답변 알림'),
+      notifyComments: t.notifyComments || (isVi ? 'Thông báo bình luận' : isEn ? 'Comment notifications' : '댓글 알림'),
+      notifyReplies: t.notifyReplies || (isVi ? 'Thông báo phản hồi' : isEn ? 'Reply notifications' : '대댓글 알림'),
+      notifyAdoptions: t.notifyAdoptions || (isVi ? 'Thông báo chấp nhận' : isEn ? 'Adoption notifications' : '채택 알림'),
+      notifyFollows: t.notifyFollows || (isVi ? 'Thông báo theo dõi' : isEn ? 'Follow notifications' : '팔로우 알림'),
+      notifyAllDesc:
+        t.notifyAllDesc ||
+        (isVi
+          ? 'Bật hoặc tắt tất cả thông báo cùng lúc'
+          : isEn
+            ? 'Turn on or off all notifications at once'
+            : '모든 알림을 한 번에 켜거나 끕니다'),
+      notifyAnswersDesc:
+        t.notifyAnswersDesc ||
+        (isVi
+          ? 'Nhận thông báo khi có người trả lời câu hỏi của bạn'
+          : isEn
+            ? 'Get notified when someone answers your question'
+            : '내 질문에 새 답변이 달릴 때 알림을 받습니다'),
+      notifyCommentsDesc:
+        t.notifyCommentsDesc ||
+        (isVi
+          ? 'Nhận thông báo khi có người bình luận bài viết của bạn'
+          : isEn
+            ? 'Get notified when someone comments on your post'
+            : '내 게시글에 새 댓글이 달릴 때 알림을 받습니다'),
+      notifyRepliesDesc:
+        t.notifyRepliesDesc ||
+        (isVi
+          ? 'Nhận thông báo khi có người phản hồi bình luận của bạn'
+          : isEn
+            ? 'Get notified when someone replies to your comment'
+            : '내 댓글에 답글이 달릴 때 알림을 받습니다'),
+      notifyAdoptionsDesc:
+        t.notifyAdoptionsDesc ||
+        (isVi
+          ? 'Nhận thông báo khi câu trả lời của bạn được chấp nhận'
+          : isEn
+            ? 'Get notified when your answer is adopted'
+            : '내 답변이 채택되었을 때 알림을 받습니다'),
+      notifyFollowsDesc:
+        t.notifyFollowsDesc ||
+        (isVi
+          ? 'Nhận thông báo khi có người theo dõi mới'
+          : isEn
+            ? 'Get notified when you have a new follower'
+            : '새로운 팔로워가 생길 때 알림을 받습니다'),
+      saveButton: t.saveButton || (isVi ? 'Lưu' : isEn ? 'Save' : '저장하기'),
+      cancelButton: t.cancelButton || tCommon.cancel || (isVi ? 'Huỷ' : isEn ? 'Cancel' : '취소'),
+    };
+  }, [lang, t, tCommon]);
 
   const { data: profile, isLoading: profileLoading } = useMyProfile({
     enabled: !!user?.id,
@@ -282,13 +405,7 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
 
     try {
       const normalizedName = normalizeDisplayName(formData.name);
-      const invalidNameLabel =
-        t.nameValidationError ||
-        (lang === 'vi'
-          ? `Biệt danh phải từ ${DISPLAY_NAME_MIN_LENGTH}–${DISPLAY_NAME_MAX_LENGTH} ký tự.`
-          : lang === 'en'
-            ? `Nickname must be ${DISPLAY_NAME_MIN_LENGTH}–${DISPLAY_NAME_MAX_LENGTH} characters.`
-            : `닉네임은 ${DISPLAY_NAME_MIN_LENGTH}~${DISPLAY_NAME_MAX_LENGTH}자여야 합니다.`);
+      const invalidNameLabel = copy.nameValidationError;
 
       if (normalizedName.length < DISPLAY_NAME_MIN_LENGTH) {
         toast.error(invalidNameLabel);
@@ -314,11 +431,11 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
 
       await updateSession({ name: normalizedName });
 
-      toast.success(t.updateSuccess || '프로필이 업데이트되었습니다.');
+      toast.success(copy.updateSuccess);
       router.push(`/${lang}/profile/${user?.id}`);
     } catch (error) {
       console.error('Failed to update profile:', error);
-      toast.error(t.updateFailed || '프로필 업데이트에 실패했습니다.');
+      toast.error(copy.updateFailed);
     } finally {
       setIsSubmitting(false);
     }
@@ -350,36 +467,15 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
     if (!file || !user?.id) return;
     const previousAvatar = avatarPreviewOverride || profile?.avatar || user?.image || null;
 
-    const onlyImagesLabel =
-      lang === 'vi' ? 'Chỉ cho phép tệp ảnh.' : lang === 'en' ? 'Only image files are allowed.' : '이미지 파일만 업로드할 수 있습니다.';
-    const tooLargeLabel =
-      lang === 'vi' ? 'Kích thước ảnh phải ≤ 20MB.' : lang === 'en' ? 'Image must be 20MB or less.' : '이미지 크기는 20MB 이하여야 합니다.';
-    const uploadFailedLabel =
-      lang === 'vi' ? 'Tải ảnh đại diện thất bại.' : lang === 'en' ? 'Failed to upload profile photo.' : '프로필 사진 업로드에 실패했습니다.';
-    const uploadSuccessLabel =
-      lang === 'vi' ? 'Đã cập nhật ảnh đại diện.' : lang === 'en' ? 'Profile photo updated.' : '프로필 사진이 업데이트되었습니다.';
-    const decodeFailedLabel =
-      lang === 'vi'
-        ? 'Không thể xử lý ảnh. Vui lòng chọn ảnh JPG/PNG.'
-        : lang === 'en'
-          ? 'Failed to process image. Please choose a JPG/PNG.'
-          : '이미지를 처리할 수 없습니다. JPG/PNG 이미지를 선택해주세요.';
-    const heicUnsupportedLabel =
-      lang === 'vi'
-        ? 'Ảnh HEIC/HEIF chưa được hỗ trợ. Vui lòng chọn JPG/PNG.'
-        : lang === 'en'
-          ? 'HEIC/HEIF is not supported. Please choose a JPG/PNG.'
-          : 'HEIC/HEIF 형식은 아직 지원되지 않습니다. JPG/PNG 이미지를 선택해주세요.';
-
     const isImageFile = file.type.startsWith('image/') || /\.(png|jpe?g|gif|webp|heic|heif)$/i.test(file.name || '');
     if (!isImageFile) {
-      toast.error(onlyImagesLabel);
+      toast.error(copy.avatarOnlyImages);
       event.target.value = '';
       return;
     }
 
     if (file.size > 20 * 1024 * 1024) {
-      toast.error(tooLargeLabel);
+      toast.error(copy.avatarTooLarge);
       event.target.value = '';
       return;
     }
@@ -396,7 +492,7 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
       try {
         normalizedFile = await normalizeAvatarImage(file);
       } catch {
-        toast.error(isHeicImage(file) ? heicUnsupportedLabel : decodeFailedLabel);
+        toast.error(isHeicImage(file) ? copy.avatarHeicUnsupported : copy.avatarDecodeFailed);
         setIsAvatarUploading(false);
         event.target.value = '';
         return;
@@ -418,7 +514,7 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
       const result = await res.json();
 
       if (!res.ok || !result?.success || !result?.data?.url) {
-        throw new Error(result?.error || uploadFailedLabel);
+        throw new Error(result?.error || copy.avatarUploadFailed);
       }
 
       const uploadedUrl = String(result.data.url);
@@ -439,7 +535,7 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
       queryClient.invalidateQueries({ queryKey: queryKeys.users.me() });
       queryClient.invalidateQueries({ queryKey: queryKeys.users.detail(user.id) });
       queryClient.invalidateQueries({ queryKey: queryKeys.posts.all });
-      toast.success(t.avatarUploadSuccess || uploadSuccessLabel);
+      toast.success(copy.avatarUploadSuccess);
     } catch (error) {
       console.error('Failed to upload avatar:', error);
       if (avatarBlobUrlRef.current) {
@@ -447,7 +543,7 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
         avatarBlobUrlRef.current = null;
       }
       setAvatarPreviewOverride(previousAvatar);
-      toast.error((error instanceof Error ? error.message : '') || t.avatarUploadFailed || uploadFailedLabel);
+      toast.error((error instanceof Error ? error.message : '') || copy.avatarUploadFailed);
     } finally {
       setIsAvatarUploading(false);
       event.target.value = '';
@@ -463,7 +559,7 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
             className="flex items-center gap-2 text-gray-600 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
           >
             <ArrowLeft className="w-5 h-5" />
-            {t.backButton || '뒤로 가기'}
+            {copy.backButton}
           </button>
         </div>
       </div>
@@ -471,14 +567,14 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
       <div className="container mx-auto px-4 py-8">
         <div className="max-w-2xl mx-auto">
           <div className="bg-white dark:bg-gray-800 rounded-xl shadow-md border border-gray-200/50 dark:border-gray-700/50 p-6">
-            <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">{t.pageTitle || '프로필 수정'}</h1>
+            <h1 className="text-2xl font-bold text-gray-900 dark:text-white mb-6">{copy.pageTitle}</h1>
 
             <form onSubmit={handleSubmit} className="space-y-6">
               <div className="flex flex-col items-center gap-4 pb-6 border-b border-gray-200 dark:border-gray-700">
                 <div className="relative group">
                   <Image
                     src={avatarPreview}
-                    alt={formData.name || 'Profile'}
+                    alt={formData.name || copy.profileAlt}
                     width={128}
                     height={128}
                     unoptimized={avatarUnoptimized}
@@ -495,7 +591,7 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
                     type="button"
                     onClick={handleAvatarPick}
                     disabled={!user?.id || isAvatarUploading}
-                    aria-label={avatarChangeLabel}
+                    aria-label={copy.avatarChange}
                     className="absolute bottom-0 right-0 bg-gradient-to-r from-red-600 to-amber-500 text-white rounded-full p-2.5 hover:from-red-700 hover:to-amber-600 transition-all duration-300 shadow-lg"
                   >
                     {isAvatarUploading ? (
@@ -506,14 +602,14 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
                   </button>
                 </div>
                 <div className="flex items-center gap-2 text-sm text-gray-500 dark:text-gray-400">
-                  <span>{avatarChangeLabel}</span>
+                  <span>{copy.avatarChange}</span>
                   <Tooltip
-                    content={avatarTooltipText}
+                    content={copy.avatarTooltip}
                     position="top"
                   >
                     <button
                       type="button"
-                      aria-label={avatarTooltipText}
+                      aria-label={copy.avatarTooltip}
                       className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white"
                     >
                       <Info className="h-4 w-4" />
@@ -525,15 +621,15 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
               <div>
                 <div className="flex items-center gap-2 mb-2">
                   <label htmlFor="name" className="block text-sm font-semibold text-gray-700 dark:text-gray-300">
-                    {t.nameLabel || '이름'}
+                    {copy.nameLabel}
                   </label>
                   <Tooltip
-                    content={nameTooltipText}
+                    content={copy.nameTooltip}
                     position="top"
                   >
                     <button
                       type="button"
-                      aria-label={nameTooltipText}
+                      aria-label={copy.nameTooltip}
                       className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white"
                     >
                       <Info className="h-4 w-4" />
@@ -547,22 +643,22 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
                   onChange={(e) => setFormData({ ...formData, name: e.target.value })}
                   maxLength={DISPLAY_NAME_MAX_LENGTH}
                   className="w-full px-4 py-2.5 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-all"
-                  placeholder={t.namePlaceholder || '이름을 입력하세요'}
+                  placeholder={copy.namePlaceholder}
                 />
               </div>
 
               <div>
                 <div className="flex items-center gap-2 mb-2">
                   <label htmlFor="bio" className="block text-sm font-semibold text-gray-700 dark:text-gray-300">
-                    {t.bioLabel || '자기소개'}
+                    {copy.bioLabel}
                   </label>
                   <Tooltip
-                    content={bioTooltipText}
+                    content={copy.bioTooltip}
                     position="top"
                   >
                     <button
                       type="button"
-                      aria-label={bioTooltipText}
+                      aria-label={copy.bioTooltip}
                       className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white"
                     >
                       <Info className="h-4 w-4" />
@@ -575,7 +671,7 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
                   onChange={(e) => setFormData({ ...formData, bio: e.target.value })}
                   rows={4}
                   className="w-full px-4 py-2.5 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent resize-none transition-all"
-                  placeholder={t.bioPlaceholder || '자기소개를 입력하세요'}
+                  placeholder={copy.bioPlaceholder}
                 />
               </div>
 
@@ -583,15 +679,15 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
                 <div>
                   <div className="flex items-center gap-2 mb-2">
                     <label htmlFor="gender" className="block text-sm font-semibold text-gray-700 dark:text-gray-300">
-                      {t.genderLabel || '성별'}
+                      {copy.genderLabel}
                     </label>
                     <Tooltip
-                      content={genderTooltipText}
+                      content={copy.genderTooltip}
                       position="top"
                     >
                       <button
                         type="button"
-                        aria-label={genderTooltipText}
+                        aria-label={copy.genderTooltip}
                         className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white"
                       >
                         <Info className="h-4 w-4" />
@@ -604,25 +700,25 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
                     onChange={(e) => setFormData({ ...formData, gender: e.target.value })}
                     className="w-full px-4 py-2.5 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-all"
                   >
-                    <option value="">{t.genderSelect || '선택'}</option>
-                    <option value="male">{t.genderMale || '남성'}</option>
-                    <option value="female">{t.genderFemale || '여성'}</option>
-                    <option value="other">{t.genderOther || '기타'}</option>
+                    <option value="">{copy.selectLabel}</option>
+                    <option value="male">{copy.genderMale}</option>
+                    <option value="female">{copy.genderFemale}</option>
+                    <option value="other">{copy.genderOther}</option>
                   </select>
                 </div>
 
                 <div>
                   <div className="flex items-center gap-2 mb-2">
                     <label htmlFor="ageGroup" className="block text-sm font-semibold text-gray-700 dark:text-gray-300">
-                      {t.ageGroupLabel || '연령대'}
+                      {copy.ageGroupLabel}
                     </label>
                     <Tooltip
-                      content={ageGroupTooltipText}
+                      content={copy.ageGroupTooltip}
                       position="top"
                     >
                       <button
                         type="button"
-                        aria-label={ageGroupTooltipText}
+                        aria-label={copy.ageGroupTooltip}
                         className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white"
                       >
                         <Info className="h-4 w-4" />
@@ -635,28 +731,28 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
                     onChange={(e) => setFormData({ ...formData, ageGroup: e.target.value })}
                     className="w-full px-4 py-2.5 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-all"
                   >
-                    <option value="">{t.genderSelect || '선택'}</option>
-                    <option value="10s">{t.ageGroup10s || '10대'}</option>
-                    <option value="20s">{t.ageGroup20s || '20대'}</option>
-                    <option value="30s">{t.ageGroup30s || '30대'}</option>
-                    <option value="40s">{t.ageGroup40s || '40대'}</option>
-                    <option value="50s">{t.ageGroup50s || '50대'}</option>
-                    <option value="60plus">{t.ageGroup60plus || '60대+'}</option>
+                    <option value="">{copy.selectLabel}</option>
+                    <option value="10s">{copy.ageGroup10s}</option>
+                    <option value="20s">{copy.ageGroup20s}</option>
+                    <option value="30s">{copy.ageGroup30s}</option>
+                    <option value="40s">{copy.ageGroup40s}</option>
+                    <option value="50s">{copy.ageGroup50s}</option>
+                    <option value="60plus">{copy.ageGroup60plus}</option>
                   </select>
                 </div>
 
                 <div>
                   <div className="flex items-center gap-2 mb-2">
                     <label htmlFor="userType" className="block text-sm font-semibold text-gray-700 dark:text-gray-300">
-                      {t.userTypeLabel || t.statusLabel || (lang === 'vi' ? 'Loại người dùng' : lang === 'en' ? 'User type' : '사용자 유형')}
+                      {copy.userTypeLabel}
                     </label>
                     <Tooltip
-                      content={userTypeTooltipText}
+                      content={copy.userTypeTooltip}
                       position="top"
                     >
                       <button
                         type="button"
-                        aria-label={userTypeTooltipText}
+                        aria-label={copy.userTypeTooltip}
                         className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white"
                       >
                         <Info className="h-4 w-4" />
@@ -669,10 +765,10 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
                     onChange={(e) => setFormData({ ...formData, userType: e.target.value })}
                     className="w-full px-4 py-2.5 bg-white dark:bg-gray-700 border border-gray-300 dark:border-gray-600 text-gray-900 dark:text-white rounded-lg focus:outline-none focus:ring-2 focus:ring-red-500 focus:border-transparent transition-all"
                   >
-                    <option value="">{t.genderSelect || '선택'}</option>
-                    <option value="student">{t.userTypeStudent || t.statusStudent || (lang === 'vi' ? 'Sinh viên' : lang === 'en' ? 'Student' : '학생')}</option>
-                    <option value="worker">{t.userTypeWorker || t.statusWorker || (lang === 'vi' ? 'Người lao động' : lang === 'en' ? 'Worker' : '근로자')}</option>
-                    <option value="resident">{t.userTypeResident || (lang === 'vi' ? 'Cư dân' : lang === 'en' ? 'Resident' : '거주자')}</option>
+                    <option value="">{copy.selectLabel}</option>
+                    <option value="student">{copy.userTypeStudent}</option>
+                    <option value="worker">{copy.userTypeWorker}</option>
+                    <option value="resident">{copy.userTypeResident}</option>
                   </select>
                 </div>
               </div>
@@ -680,26 +776,26 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
               <div className="pt-6 border-t border-gray-200 dark:border-gray-700">
                 <div className="flex items-center gap-3 mb-4">
                   <Bell className="w-5 h-5 text-red-600 dark:text-red-400" />
-                  <h2 className="text-lg font-bold text-gray-900 dark:text-white">{t.notificationTitle || '알림 설정'}</h2>
+                  <h2 className="text-lg font-bold text-gray-900 dark:text-white">{copy.notificationTitle}</h2>
                 </div>
 
                 <div className="space-y-4">
                   {(['all', 'answers', 'comments', 'replies', 'adoptions', 'follows'] as const).map((key) => {
                     const labels = {
-                      all: t.notifyAll || '전체 알림',
-                      answers: t.notifyAnswers || '답변 알림',
-                      comments: t.notifyComments || '댓글 알림',
-                      replies: t.notifyReplies || '대댓글 알림',
-                      adoptions: t.notifyAdoptions || '채택 알림',
-                      follows: t.notifyFollows || '팔로우 알림',
+                      all: copy.notifyAll,
+                      answers: copy.notifyAnswers,
+                      comments: copy.notifyComments,
+                      replies: copy.notifyReplies,
+                      adoptions: copy.notifyAdoptions,
+                      follows: copy.notifyFollows,
                     };
                     const descs = {
-                      all: t.notifyAllDesc || '모든 알림을 한 번에 켜거나 끕니다',
-                      answers: t.notifyAnswersDesc || '내 질문에 새 답변이 달릴 때 알림을 받습니다',
-                      comments: t.notifyCommentsDesc || '내 게시글에 새 댓글이 달릴 때 알림을 받습니다',
-                      replies: t.notifyRepliesDesc || '내 댓글에 답글이 달릴 때 알림을 받습니다',
-                      adoptions: t.notifyAdoptionsDesc || '내 답변이 채택되었을 때 알림을 받습니다',
-                      follows: t.notifyFollowsDesc || '새로운 팔로워가 생길 때 알림을 받습니다',
+                      all: copy.notifyAllDesc,
+                      answers: copy.notifyAnswersDesc,
+                      comments: copy.notifyCommentsDesc,
+                      replies: copy.notifyRepliesDesc,
+                      adoptions: copy.notifyAdoptionsDesc,
+                      follows: copy.notifyFollowsDesc,
                     };
                     return (
                     <div
@@ -750,7 +846,7 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
                   ) : (
                     <>
                       <Save className="w-5 h-5" />
-                      {t.saveButton || '저장하기'}
+                      {copy.saveButton}
                     </>
                   )}
                 </button>
@@ -760,7 +856,7 @@ export default function ProfileEditClient({ lang, translations }: ProfileEditCli
                   disabled={isSubmitting}
                   className="flex-1 px-6 py-3 bg-white dark:bg-gray-700 text-gray-700 dark:text-gray-300 font-semibold border-2 border-gray-300 dark:border-gray-600 rounded-lg hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-gray-500 focus:ring-offset-2 transition-all duration-300 disabled:opacity-50"
                 >
-                  {t.cancelButton || '취소'}
+                  {copy.cancelButton}
                 </button>
               </div>
             </form>

--- a/src/components/organisms/CategorySidebar.tsx
+++ b/src/components/organisms/CategorySidebar.tsx
@@ -47,6 +47,166 @@ export default function CategorySidebar({
   const { openLoginPrompt } = useLoginPrompt();
   const containerRef = useRef<HTMLElement | null>(null);
 
+  const labelFallbacks = useMemo(() => {
+    if (locale === 'en') {
+      return {
+        menu: 'Menu',
+        popular: 'Popular',
+        latest: 'Latest',
+        following: 'Following',
+        subscribed: 'Subscribed',
+        askQuestion: 'Ask a question',
+        sharePost: 'Share',
+        verificationRequest: 'Verify',
+        subscribe: 'Subscribe',
+        subscribedLabel: 'Subscribed',
+      };
+    }
+    if (locale === 'vi') {
+      return {
+        menu: 'Menu',
+        popular: 'Phổ biến',
+        latest: 'Mới nhất',
+        following: 'Đang theo dõi',
+        subscribed: 'Đã theo dõi',
+        askQuestion: 'Đặt câu hỏi',
+        sharePost: 'Chia sẻ',
+        verificationRequest: 'Xác minh',
+        subscribe: 'Theo dõi',
+        subscribedLabel: 'Đang theo dõi',
+      };
+    }
+    return {
+      menu: '메뉴',
+      popular: '인기',
+      latest: '최신',
+      following: '팔로잉',
+      subscribed: '구독',
+      askQuestion: '질문하기',
+      sharePost: '공유하기',
+      verificationRequest: '인증하기',
+      subscribe: '구독',
+      subscribedLabel: '구독 중',
+    };
+  }, [locale]);
+  const menuLabelFallbacks: Record<string, string> = {
+    popular: labelFallbacks.popular,
+    latest: labelFallbacks.latest,
+    following: labelFallbacks.following,
+    subscribed: labelFallbacks.subscribed,
+  };
+  const tooltipFallbacks = useMemo(() => {
+    if (locale === 'en') {
+      return {
+        popular: 'See the most popular posts right now.',
+        latest: 'Browse the newest posts by time.',
+        following: 'See posts from people you follow.',
+        subscribed: 'See posts from categories you follow.',
+        feedback: 'Send feedback or report a bug.',
+      };
+    }
+    if (locale === 'vi') {
+      return {
+        popular: 'Xem bài viết đang được quan tâm nhất.',
+        latest: 'Xem bài mới nhất theo thời gian.',
+        following: 'Chỉ xem bài từ người bạn đang theo dõi.',
+        subscribed: 'Xem bài theo danh mục bạn đã đăng ký.',
+        feedback: 'Gửi phản hồi hoặc báo lỗi cho đội ngũ.',
+      };
+    }
+    return {
+      popular: '지금 가장 많이 보는 글을 모아서 보여줘요.',
+      latest: '최신 글을 시간순으로 보여줘요.',
+      following: '팔로우한 사람들의 글만 모아볼 수 있어요.',
+      subscribed: '구독한 카테고리 글만 모아볼 수 있어요.',
+      feedback: '피드백이나 버그를 제보할 수 있어요.',
+    };
+  }, [locale]);
+  const ctaTooltipFallbacks = useMemo(() => {
+    if (locale === 'en') {
+      return {
+        askQuestion:
+          'Ask about visa, jobs, or life in Korea\nCommunity & verified users can help\nInclude your situation, visa type, and timeline',
+        sharePost:
+          'Share experience, official links, or notices\nHelp others save time\nAdd source and date for trust',
+        verificationRequest:
+          'Apply to get a verified badge\nBoost trust and visibility\nSubmit a request and wait for review',
+      };
+    }
+    if (locale === 'vi') {
+      return {
+        askQuestion:
+          'Đặt câu hỏi về visa/việc làm/cuộc sống\nCộng đồng & người dùng xác minh sẽ hỗ trợ\nGhi rõ tình huống, loại visa, và thời hạn',
+        sharePost:
+          'Chia sẻ kinh nghiệm, link chính thức, hoặc thông báo\nGiúp người khác tiết kiệm thời gian\nNhớ ghi nguồn và ngày đăng',
+        verificationRequest:
+          'Xác minh hồ sơ để hiển thị huy hiệu\nTăng độ tin cậy và ưu tiên hiển thị\nGửi yêu cầu và chờ xét duyệt',
+      };
+    }
+    return {
+      askQuestion: '비자·취업·생활 질문을 올리면\n커뮤니티와 인증 사용자가 함께 도와줘요\n상황/비자타입/기간을 같이 적어주세요',
+      sharePost: '내 경험과 지식을 모두와 함께 공유해봅시다.',
+      verificationRequest: '인증을 받으면 프로필에 인증 마크가 표시돼요\n신뢰도/노출 가중치가 올라갑니다\n신청 후 검토를 기다려주세요',
+    };
+  }, [locale]);
+  const toastFallbacks = useMemo(() => {
+    if (locale === 'en') {
+      return {
+        subscribed: 'Subscribed.',
+        unsubscribed: 'Unsubscribed.',
+        subscribeError: 'Failed to subscribe.',
+      };
+    }
+    if (locale === 'vi') {
+      return {
+        subscribed: 'Đã theo dõi.',
+        unsubscribed: 'Đã hủy theo dõi.',
+        subscribeError: 'Lỗi khi theo dõi.',
+      };
+    }
+    return {
+      subscribed: '구독되었습니다.',
+      unsubscribed: '구독이 해제되었습니다.',
+      subscribeError: '구독 처리 중 오류가 발생했습니다.',
+    };
+  }, [locale]);
+  const sectionFallbacks = useMemo(() => {
+    if (locale === 'en') {
+      return {
+        categories: 'Categories',
+        mySubscriptions: 'My Subscriptions',
+        noSubscriptions: 'No subscriptions yet.',
+      };
+    }
+    if (locale === 'vi') {
+      return {
+        categories: 'Danh mục',
+        mySubscriptions: 'Theo dõi của tôi',
+        noSubscriptions: 'Chưa có danh mục theo dõi.',
+      };
+    }
+    return {
+      categories: '카테고리',
+      mySubscriptions: '내 구독',
+      noSubscriptions: '구독 중인 카테고리가 없습니다.',
+    };
+  }, [locale]);
+  const menuTitleLabel = t.menu || labelFallbacks.menu;
+  const askQuestionLabel = t.askQuestion || labelFallbacks.askQuestion;
+  const sharePostLabel = t.sharePost || labelFallbacks.sharePost;
+  const verificationRequestLabel = t.verificationRequest || labelFallbacks.verificationRequest;
+  const subscribeLabel = t.subscribe || labelFallbacks.subscribe;
+  const subscribedLabel = t.subscribedLabel || t.subscribed || labelFallbacks.subscribedLabel;
+  const categoriesLabel = t.categories || sectionFallbacks.categories;
+  const mySubscriptionsLabel = t.mySubscriptions || sectionFallbacks.mySubscriptions;
+  const noSubscriptionsLabel = t.noSubscriptions || sectionFallbacks.noSubscriptions;
+  const subscribedToastLabel = t.subscribedToast || toastFallbacks.subscribed;
+  const unsubscribedToastLabel = t.unsubscribedToast || toastFallbacks.unsubscribed;
+  const subscribeErrorLabel = t.subscribeError || toastFallbacks.subscribeError;
+  const askQuestionTooltipText = t.askQuestionTooltip || ctaTooltipFallbacks.askQuestion;
+  const sharePostTooltipText = t.sharePostTooltip || ctaTooltipFallbacks.sharePost;
+  const verificationTooltipText = t.verificationRequestTooltip || ctaTooltipFallbacks.verificationRequest;
+
   useEffect(() => onHomeReset(() => {
     containerRef.current?.scrollTo({ top: 0, behavior: 'auto' });
   }), []);
@@ -59,41 +219,11 @@ export default function CategorySidebar({
   };
 
   const menuTooltips: Record<string, string | undefined> = {
-    popular:
-      t.popularTooltip ||
-      (locale === 'vi'
-        ? 'Xem bài viết đang được quan tâm nhất.'
-        : locale === 'en'
-          ? 'See the most popular posts right now.'
-          : '지금 가장 많이 보는 글을 모아서 보여줘요.'),
-    latest:
-      t.latestTooltip ||
-      (locale === 'vi'
-        ? 'Xem bài mới nhất theo thời gian.'
-        : locale === 'en'
-          ? 'Browse the newest posts by time.'
-          : '최신 글을 시간순으로 보여줘요.'),
-    following:
-      t.followingTooltip ||
-      (locale === 'vi'
-        ? 'Chỉ xem bài từ người bạn đang theo dõi.'
-        : locale === 'en'
-          ? 'See posts from people you follow.'
-          : '팔로우한 사람들의 글만 모아볼 수 있어요.'),
-    subscribed:
-      t.subscribedTooltip ||
-      (locale === 'vi'
-        ? 'Xem bài theo danh mục bạn đã đăng ký.'
-        : locale === 'en'
-          ? 'See posts from categories you follow.'
-          : '구독한 카테고리 글만 모아볼 수 있어요.'),
-    feedback:
-      t.feedbackTooltip ||
-      (locale === 'vi'
-        ? 'Gửi phản hồi hoặc báo lỗi cho đội ngũ.'
-        : locale === 'en'
-          ? 'Send feedback or report a bug.'
-          : '피드백이나 버그를 제보할 수 있어요.'),
+    popular: t.popularTooltip || tooltipFallbacks.popular,
+    latest: t.latestTooltip || tooltipFallbacks.latest,
+    following: t.followingTooltip || tooltipFallbacks.following,
+    subscribed: t.subscribedTooltip || tooltipFallbacks.subscribed,
+    feedback: t.feedbackTooltip || tooltipFallbacks.feedback,
   };
 
   const feedbackLabel = 'Feedback';
@@ -156,18 +286,11 @@ export default function CategorySidebar({
     }
     toggleSubscription(categoryId, {
       onSuccess: (res) => {
-        const msg = res?.isSubscribed
-          ? (t.subscribedToast ||
-              (locale === 'vi' ? 'Đã theo dõi.' : locale === 'en' ? 'Subscribed.' : '구독되었습니다.'))
-          : (t.unsubscribedToast ||
-              (locale === 'vi' ? 'Đã hủy theo dõi.' : locale === 'en' ? 'Unsubscribed.' : '구독이 해제되었습니다.'));
+        const msg = res?.isSubscribed ? subscribedToastLabel : unsubscribedToastLabel;
         toast.success(msg);
       },
       onError: () => {
-        toast.error(
-          t.subscribeError ||
-            (locale === 'vi' ? 'Lỗi khi theo dõi.' : locale === 'en' ? 'Failed to subscribe.' : '구독 처리 중 오류가 발생했습니다.')
-        );
+        toast.error(subscribeErrorLabel);
       },
     });
   };
@@ -261,14 +384,14 @@ export default function CategorySidebar({
             <h3
               className={`${isMobileVariant ? '' : 'px-4 pb-2 '}text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider`}
             >
-              {t.menu || '메뉴'}
+              {menuTitleLabel}
             </h3>
           </div>
           {menuCategories.map((category) => (
             <CategoryItem
               key={category.id}
               id={category.id}
-              name={(category as { label?: string }).label || t[category.id] || category.id}
+              name={(category as { label?: string }).label || t[category.id] || menuLabelFallbacks[category.id] || category.id}
               description={showInlineDescriptions ? tooltipSummary(menuTooltips[category.id]) : undefined}
               icon={category.icon}
               count={category.count}
@@ -286,28 +409,6 @@ export default function CategorySidebar({
         {/* Create Post Section - Each action separated and emphasized */}
         <div className="py-2 space-y-2">
           {(() => {
-            const askQuestionTooltipText =
-              t.askQuestionTooltip ||
-              (locale === 'vi'
-                ? 'Đặt câu hỏi về visa/việc làm/cuộc sống\nCộng đồng & người dùng xác minh sẽ hỗ trợ\nGhi rõ tình huống, loại visa, và thời hạn'
-                : locale === 'en'
-                  ? 'Ask about visa, jobs, or life in Korea\nCommunity & verified users can help\nInclude your situation, visa type, and timeline'
-                  : '비자·취업·생활 질문을 올리면\n커뮤니티와 인증 사용자가 함께 도와줘요\n상황/비자타입/기간을 같이 적어주세요');
-            const sharePostTooltipText =
-              t.sharePostTooltip ||
-              (locale === 'vi'
-                ? 'Chia sẻ kinh nghiệm, link chính thức, hoặc thông báo\nGiúp người khác tiết kiệm thời gian\nNhớ ghi nguồn và ngày đăng'
-                : locale === 'en'
-                  ? 'Share experience, official links, or notices\nHelp others save time\nAdd source and date for trust'
-                  : '경험담/공식링크/공지 등을 공유하면\n다른 사람의 시간을 절약해줘요\n출처·날짜를 함께 남겨주세요');
-            const verificationTooltipText =
-              t.verificationRequestTooltip ||
-              (locale === 'vi'
-                ? 'Xác minh hồ sơ để hiển thị huy hiệu\nTăng độ tin cậy và ưu tiên hiển thị\nGửi yêu cầu và chờ xét duyệt'
-                : locale === 'en'
-                  ? 'Apply to get a verified badge\nBoost trust and visibility\nSubmit a request and wait for review'
-                  : '인증을 받으면 프로필에 인증 마크가 표시돼요\n신뢰도/노출 가중치가 올라갑니다\n신청 후 검토를 기다려주세요');
-
             const askQuestionDescription = isMobileVariant || showInlineDescriptions ? tooltipSummary(askQuestionTooltipText) : undefined;
             const sharePostDescription = isMobileVariant || showInlineDescriptions ? tooltipSummary(sharePostTooltipText) : undefined;
             const verificationDescription = isMobileVariant || showInlineDescriptions ? tooltipSummary(verificationTooltipText) : undefined;
@@ -316,7 +417,7 @@ export default function CategorySidebar({
               <>
           <CategoryItem
             id="ask-question"
-            name={t.askQuestion || '질문하기'}
+            name={askQuestionLabel}
             description={askQuestionDescription}
             icon={MessageCircle}
             count={0}
@@ -327,7 +428,7 @@ export default function CategorySidebar({
           />
           <CategoryItem
             id="share-post"
-            name={t.sharePost || (locale === 'vi' ? 'Chia sẻ' : locale === 'en' ? 'Share' : '공유하기')}
+            name={sharePostLabel}
             description={sharePostDescription}
             icon={Share2}
             count={0}
@@ -338,7 +439,7 @@ export default function CategorySidebar({
           />
           <CategoryItem
             id="verification-request"
-            name={t.verificationRequest || (locale === 'vi' ? 'Xác minh' : locale === 'en' ? 'Verify' : '인증하기')}
+            name={verificationRequestLabel}
             description={verificationDescription}
             icon={ShieldCheck}
             count={0}
@@ -354,7 +455,7 @@ export default function CategorySidebar({
 
         <div className="py-3 space-y-3 border-b border-gray-200/40 dark:border-gray-700/40 border-t border-gray-200/40 dark:border-gray-700/40 mt-2">
           <h3 className="px-4 pb-2 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-            {t.categories || (locale === 'vi' ? 'Danh mục' : locale === 'en' ? 'Categories' : '카테고리')}
+            {categoriesLabel}
           </h3>
           <div className="space-y-1">
             {groupOptions.map((group) => (
@@ -397,8 +498,8 @@ export default function CategorySidebar({
                           >
                             <span className="block leading-none">
                               {subscribed
-                                ? (t.subscribedLabel || t.subscribed || '구독 중')
-                                : (t.subscribe || '구독')}
+                                ? subscribedLabel
+                                : subscribeLabel}
                             </span>
                           </button>
                           ) : null}
@@ -414,7 +515,7 @@ export default function CategorySidebar({
 
         <div className="py-3 pb-16 space-y-3">
           <h3 className="px-4 text-xs font-semibold text-gray-500 dark:text-gray-400 uppercase tracking-wider">
-            {t.mySubscriptions || '내 구독'}
+            {mySubscriptionsLabel}
           </h3>
           {topicSubscriptions.length > 0 ? (
             <div className="space-y-1">
@@ -434,7 +535,7 @@ export default function CategorySidebar({
                     className="shrink-0 whitespace-nowrap text-[11px] min-h-[32px] min-w-[84px] sm:min-w-[96px] px-2.5 sm:px-3 py-1.5 rounded-full border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 bg-transparent hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
                   >
                     <span className="block leading-none">
-                      {t.subscribedLabel || t.subscribed || '구독 중'}
+                      {subscribedLabel}
                     </span>
                   </button>
                 </div>
@@ -442,7 +543,7 @@ export default function CategorySidebar({
             </div>
           ) : (
             <div className="px-4 py-3 text-xs text-gray-500 dark:text-gray-400">
-              {t.noSubscriptions || '구독 중인 카테고리가 없습니다.'}
+              {noSubscriptionsLabel}
             </div>
           )}
         </div>

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -7,6 +7,7 @@ import { useParams } from 'next/navigation';
 import { Bell, Menu, X } from 'lucide-react';
 import Logo from '@/components/atoms/Logo';
 import Button from '@/components/atoms/Button';
+import Tooltip from '@/components/atoms/Tooltip';
 import UserProfile from '@/components/molecules/user/UserProfile';
 import LanguageSwitcher from '@/components/atoms/LanguageSwitcher';
 import { useSession, signOut } from 'next-auth/react';
@@ -94,7 +95,10 @@ export default function Header({ isMobileMenuOpen, setIsMobileMenuOpen, showBack
   const sidebarToggleLabel = tTooltip.sidebarToggle || labelFallbacks.sidebarToggle;
   const notificationsLabel = tTooltip.notifications || labelFallbacks.notifications;
   const loginLabel = t.login || labelFallbacks.login;
-  const signupLabel = t.signup || labelFallbacks.signup;
+  const signupFallback = locale === 'en' ? 'Get started' : locale === 'vi' ? 'Bắt đầu' : '바로 시작';
+  const rawSignupLabel = (t.signup || labelFallbacks.signup || '').trim();
+  const shouldOverrideSignup = !rawSignupLabel || ['Sign up', 'Sign Up', 'Đăng ký', '회원가입'].includes(rawSignupLabel);
+  const signupLabel = shouldOverrideSignup ? signupFallback : rawSignupLabel;
   const userNameFallback = labelFallbacks.userName;
 
   useEffect(() => {
@@ -150,12 +154,11 @@ export default function Header({ isMobileMenuOpen, setIsMobileMenuOpen, showBack
             </button>
           )}
           <div className="scale-90 sm:scale-100 origin-left">
-            <div className="flex items-center gap-2 min-w-0">
-              <Logo />
-              <span className="inline-block max-w-[90px] sm:max-w-[160px] text-[9px] sm:text-[11px] text-gray-500 dark:text-gray-400 leading-tight line-clamp-2">
-                {tTooltip.brandIntro || brandIntroFallback}
-              </span>
-            </div>
+            <Tooltip content={tTooltip.brandIntro || brandIntroFallback} position="below" className="vk-tooltip-brand">
+              <div aria-label={tTooltip.brandIntro || brandIntroFallback}>
+                <Logo />
+              </div>
+            </Tooltip>
           </div>
         </div>
 


### PR DESCRIPTION
@codex please review

- why: codex-subscriptions 백업에서 안전 파일만 선별 이관
- what: onboarding/notifications/new post/profile/page, header+category sidebar, rich text editor, db index + docs
- test: npm run lint
- test: npm run type-check
- test: SKIP_SITEMAP_DB=true npm run build
