### PR TITLE
[BE] user score rank

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -8,6 +8,7 @@
 - [FE] PostCard 모바일 하단 액션/카운트 한 줄 정렬 + 인증 사용자 요약 라벨 Tooltip 보강
 - [FE] 프로필 통계 5개 항목 1행 정렬 + 프로필 설정 화면 헤더를 메인 헤더와 통일
 - [FE] 피드 상단 “추천 사용자 보기” CTA 강조(그라데이션 버튼)
+- [BE] 사용자 점수 API(`/api/users/[id]/score`)에 rank 계산 추가(동점 tie-break 포함)
 - [FE] Header signup CTA를 “바로 시작하기” 계열로 정리 + 공유하기 CTA 설명 문구 업데이트
 - [FE] 온보딩 가이드/FAQ locale fallback 맵 정리 + 글쓰기 기본 태그 fallback locale 분리
 - [FE] 알림/피드백/프로필 편집/에디터 i18n fallback 보강(링크 모달/오류 메시지 포함)

--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -2741,6 +2741,24 @@ $gh-address-comments
 
 ### 0.6.3 [BE] Backend Agent
 
+#### (2025-12-20) [BE] 유저 점수 API rank 계산 추가 (P0)
+
+- 플랜(체크리스트)
+  - [x] `/api/users/[id]/score`에 rank 계산 로직 추가
+  - [x] 동점 tie-break 기준(createdAt/id)으로 일관된 순위 산출
+- 현황 분석(코드 기준)
+  - 프론트에서 rank 표시를 사용하지만 API 응답에는 rank가 누락됨
+- 변경 내용(why/what)
+  - why: 프로필/피드 점수 카드에서 rank 표기를 안정적으로 제공
+  - what: 점수 서브쿼리 + 동일 점수 tie-break로 rank 산출 후 응답 포함
+- 검증
+  - [x] npm run lint
+  - [x] SKIP_SITEMAP_DB=true npm run build
+- 변경 파일
+  - src/app/api/users/[id]/score/route.ts
+- 다음 액션/의존성
+  - 없음
+
 #### (2025-12-18) [BE] 추천 사용자 API 보강 + 과부하 방지 (P0)
 
 - 플랜(체크리스트)


### PR DESCRIPTION
@codex please review

why: rank is displayed in profile/feed score cards but API lacked rank
what:
- add score expression + rank tie-break computation in /api/users/[id]/score
- docs update (EXECUTION_PLAN + HANDOVER)
test:
- npm run lint
- SKIP_SITEMAP_DB=true npm run build
