### PR TITLE
[LEAD] i18n share key + migrate note

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -4,6 +4,8 @@
 
 ## 최근 주요 변경 사항
 
+- [LEAD] `common.share` i18n 키 추가(ko/en/vi)
+- [LEAD] DB migrate statement_timeout 우회: `PGOPTIONS='-c statement_timeout=0' npm run db:migrate`로 성공
 - [WEB] posts/trending/users posts/bookmarks API 응답을 post-list serializer로 통일(썸네일/요약/작성자 포맷 일관화)
 - [WEB] 메타데이터 baseUrl을 `SITE_URL`로 통일(홈/FAQ/게시글 상세) + UGC allowlist에 SITE_URL/API_BASE 고정
 - [FE] PostDetail/VerificationRequest fallback 보강 + 공유 CTA/로그 이벤트 보완, 팔로잉 모달에 공식/검수 카운트 전달

--- a/docs/EXECUTION_PLAN.md
+++ b/docs/EXECUTION_PLAN.md
@@ -3955,3 +3955,19 @@ $gh-address-comments
   - docs/WORKING_PLAN.md
 - 다음 액션/의존성
   - (선택) `common.share` i18n 키 추가 여부 결정
+
+#### (2025-12-20) [LEAD] i18n `common.share` 추가 + DB migrate 타임아웃 우회 (P0)
+
+- 플랜(체크리스트)
+  - [x] `messages/*`에 `common.share` 추가
+  - [x] statement_timeout 비활성화 옵션으로 DB migrate 재시도
+- 변경 내용(why/what)
+  - why: 공유 CTA 공통 라벨 누락 보완 + 로컬 migrate 블로커 해소
+  - what: ko/en/vi 공통 키 추가, `PGOPTIONS='-c statement_timeout=0'`로 마이그레이션 수행
+- 검증
+  - [x] npm run db:migrate (PGOPTIONS 적용)
+  - [ ] lint/build 재실행 없음(i18n 변경)
+- 변경 파일
+  - messages/ko.json
+  - messages/en.json
+  - messages/vi.json

--- a/messages/en.json
+++ b/messages/en.json
@@ -31,6 +31,7 @@
     "officialAnswer": "Official answer",
     "reviewedAnswer": "Reviewed answer",
     "source": "Source",
+    "share": "Share",
     "question": "Question",
     "verifiedUser": "Verified user",
     "guidelineTooltip": "Be respectful, no hate; ads/contact links may be restricted; violations can be limited or penalized"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -31,6 +31,7 @@
     "officialAnswer": "공식 답변",
     "reviewedAnswer": "검수 답변",
     "source": "출처",
+    "share": "공유",
     "question": "질문",
     "verifiedUser": "인증된 사용자",
     "guidelineTooltip": "예의·혐오 금지, 광고/연락처 제한, 위반 시 게시 제한/제재"

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -31,6 +31,7 @@
     "officialAnswer": "Câu trả lời chính thức",
     "reviewedAnswer": "Câu trả lời đã kiểm duyệt",
     "source": "Nguồn",
+    "share": "Chia sẻ",
     "question": "Câu hỏi",
     "verifiedUser": "Người dùng đã xác minh",
     "guidelineTooltip": "Tôn trọng, không lăng mạ/hận thù; bài có quảng cáo/liên hệ/liên kết có thể bị hạn chế; vi phạm có thể bị giới hạn/xử lý"


### PR DESCRIPTION
@codex please review

- why: 공유 CTA 공통 라벨 누락 보완 + migrate 블로커 기록
- what: messages/*에 common.share 추가, EXECUTION_PLAN/HANDOVER에 db migrate 우회 기록
- test: PGOPTIONS='-c statement_timeout=0' npm run db:migrate
