### PR TITLE
[WEB] expand metadata builder to static pages

### DIFF
--- a/docs/WORKING_PLAN.md
+++ b/docs/WORKING_PLAN.md
@@ -827,6 +827,42 @@ $gh-address-comments
 - 다음 액션/의존성
   - 프로필 메타 이관 필요 시 범위 확정
 
+#### (2025-12-20) [WEB] P0-12 메타 이관 확장(정적/알림/구독/작성/가이드) (P0)
+
+- 플랜(체크리스트)
+  - [x] 정적 페이지(about/faq/privacy/terms) 메타 이관
+  - [x] 피드백/알림/구독/작성 메타 이관
+  - [x] 가이드(신뢰 배지) 메타 이관
+- 현황 분석(코드 기준)
+  - 현재 구현/문제 위치: `src/app/[lang]/(main)/*/page.tsx`, `src/app/[lang]/guide/trust-badges/page.tsx`
+  - 재현/리스크: 정적/유틸 페이지에서 메타 로직 분산
+- 변경 내용(why/what)
+  - why: 메타/키워드 파이프라인 통일 유지
+  - what: 해당 페이지들의 `generateMetadata`를 공용 빌더로 이관
+- 검증
+  - [x] npm run lint
+  - [ ] npm run type-check
+  - [ ] npm run build
+- 변경 파일
+  - src/app/[lang]/(main)/about/page.tsx
+  - src/app/[lang]/(main)/faq/page.tsx
+  - src/app/[lang]/(main)/privacy/page.tsx
+  - src/app/[lang]/(main)/terms/page.tsx
+  - src/app/[lang]/(main)/feedback/page.tsx
+  - src/app/[lang]/(main)/notifications/page.tsx
+  - src/app/[lang]/(main)/posts/new/page.tsx
+  - src/app/[lang]/(main)/subscriptions/page.tsx
+  - src/app/[lang]/guide/trust-badges/page.tsx
+  - docs/WORKING_PLAN.md
+- 커밋 준비(필수)
+  - 커밋 스코프(요청 1건): P0-12 metadata builder rollout (static pages)
+  - 필요한 파일 목록: 위 변경 파일
+  - 필요 검증(lint/type-check/build/기타): lint 완료, type-check/build 미실행
+  - 의존성/선행 작업: 없음
+  - 커밋 메시지 제안: [WEB] expand metadata builder to static pages
+- 다음 액션/의존성
+  - 프로필 메타 이관 필요 시 범위 확정
+
 #### (2025-12-20) [WEB] P0-14 피드백 폼 필드 최소화 (P0)
 
 - 플랜(체크리스트)

--- a/src/app/[lang]/(main)/about/page.tsx
+++ b/src/app/[lang]/(main)/about/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
 import MainLayout from '@/components/templates/MainLayout';
 import { getDictionary } from '@/i18n/get-dictionary';
-import { i18n, type Locale } from '@/i18n/config';
-import { SITE_URL } from '@/lib/siteUrl';
+import { type Locale } from '@/i18n/config';
+import { buildPageMetadata } from '@/lib/seo/metadata';
+import { buildKeywords, flattenKeywords } from '@/lib/seo/keywords';
 
 type PageProps = {
   params: Promise<{ lang: Locale }>;
@@ -12,29 +13,30 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { lang } = await params;
   const dict = await getDictionary(lang);
   const meta = dict.metadata as Record<string, any>;
-  const baseUrl = SITE_URL;
-  const currentUrl = `${baseUrl}/${lang}/about`;
+  const title =
+    meta.about?.title ||
+    (lang === 'en'
+      ? 'About - viet kconnect'
+      : lang === 'vi'
+        ? 'Giới thiệu - viet kconnect'
+        : '소개 - viet kconnect');
+  const description =
+    meta.about?.description ||
+    (lang === 'en'
+      ? 'Learn what viet kconnect is and how it works.'
+      : lang === 'vi'
+        ? 'Tìm hiểu về viet kconnect và cách hoạt động.'
+        : 'viet kconnect 소개 및 운영 방식.');
+  const keywords = flattenKeywords(buildKeywords({ title, content: description }));
 
-  return {
-    title:
-      meta.about?.title ||
-      (lang === 'en'
-        ? 'About - viet kconnect'
-        : lang === 'vi'
-          ? 'Giới thiệu - viet kconnect'
-          : '소개 - viet kconnect'),
-    description:
-      meta.about?.description ||
-      (lang === 'en'
-        ? 'Learn what viet kconnect is and how it works.'
-        : lang === 'vi'
-          ? 'Tìm hiểu về viet kconnect và cách hoạt động.'
-          : 'viet kconnect 소개 및 운영 방식.'),
-    alternates: {
-      canonical: currentUrl,
-      languages: Object.fromEntries(i18n.locales.map((l) => [l, `${baseUrl}/${l}/about`])),
-    },
-  };
+  return buildPageMetadata({
+    locale: lang,
+    path: '/about',
+    title,
+    description,
+    siteName: (meta?.home as Record<string, string>)?.siteName,
+    keywords,
+  });
 }
 
 export default async function AboutPage({ params }: PageProps) {

--- a/src/app/[lang]/(main)/faq/page.tsx
+++ b/src/app/[lang]/(main)/faq/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
 import MainLayout from '@/components/templates/MainLayout';
 import { getDictionary } from '@/i18n/get-dictionary';
-import { i18n, type Locale } from '@/i18n/config';
-import { SITE_URL } from '@/lib/siteUrl';
+import { type Locale } from '@/i18n/config';
+import { buildPageMetadata } from '@/lib/seo/metadata';
+import { buildKeywords, flattenKeywords } from '@/lib/seo/keywords';
 
 type PageProps = {
   params: Promise<{ lang: Locale }>;
@@ -12,29 +13,30 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { lang } = await params;
   const dict = await getDictionary(lang);
   const meta = dict.metadata as Record<string, any>;
-  const baseUrl = SITE_URL;
-  const currentUrl = `${baseUrl}/${lang}/faq`;
+  const title =
+    meta.faq?.title ||
+    (lang === 'en'
+      ? 'FAQ - viet kconnect'
+      : lang === 'vi'
+        ? 'Câu hỏi thường gặp - viet kconnect'
+        : '자주 묻는 질문 - viet kconnect');
+  const description =
+    meta.faq?.description ||
+    (lang === 'en'
+      ? 'Find answers to common questions about using viet kconnect.'
+      : lang === 'vi'
+        ? 'Giải đáp các câu hỏi phổ biến khi sử dụng viet kconnect.'
+        : 'viet kconnect 이용에 관한 자주 묻는 질문을 확인하세요.');
+  const keywords = flattenKeywords(buildKeywords({ title, content: description }));
 
-  return {
-    title:
-      meta.faq?.title ||
-      (lang === 'en'
-        ? 'FAQ - viet kconnect'
-        : lang === 'vi'
-          ? 'Câu hỏi thường gặp - viet kconnect'
-          : '자주 묻는 질문 - viet kconnect'),
-    description:
-      meta.faq?.description ||
-      (lang === 'en'
-        ? 'Find answers to common questions about using viet kconnect.'
-        : lang === 'vi'
-          ? 'Giải đáp các câu hỏi phổ biến khi sử dụng viet kconnect.'
-          : 'viet kconnect 이용에 관한 자주 묻는 질문을 확인하세요.'),
-    alternates: {
-      canonical: currentUrl,
-      languages: Object.fromEntries(i18n.locales.map((l) => [l, `${baseUrl}/${l}/faq`])),
-    },
-  };
+  return buildPageMetadata({
+    locale: lang,
+    path: '/faq',
+    title,
+    description,
+    siteName: (meta?.home as Record<string, string>)?.siteName,
+    keywords,
+  });
 }
 
 export default async function FaqPage({ params }: PageProps) {

--- a/src/app/[lang]/(main)/notifications/page.tsx
+++ b/src/app/[lang]/(main)/notifications/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from 'next';
 import { Suspense } from 'react';
 import { getDictionary } from '@/i18n/get-dictionary';
 import type { Locale } from '@/i18n/config';
+import { buildPageMetadata } from '@/lib/seo/metadata';
+import { buildKeywords, flattenKeywords } from '@/lib/seo/keywords';
 import NotificationsClient from './NotificationsClient';
 
 export const dynamic = 'force-dynamic';
@@ -35,14 +37,23 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     };
   })();
 
-  return {
-    title: t.title || fallback.title,
-    description: t.description || fallback.description,
+  const meta = (dict?.metadata as Record<string, unknown>) || {};
+  const title = t.title || fallback.title;
+  const description = t.description || fallback.description;
+  const keywords = flattenKeywords(buildKeywords({ title, content: description }));
+
+  return buildPageMetadata({
+    locale: lang,
+    path: '/notifications',
+    title,
+    description,
+    siteName: (meta?.home as Record<string, string>)?.siteName,
+    keywords,
     robots: {
       index: false,
       follow: false,
     },
-  };
+  });
 }
 
 export default async function NotificationsPage({ params }: PageProps) {

--- a/src/app/[lang]/(main)/posts/new/page.tsx
+++ b/src/app/[lang]/(main)/posts/new/page.tsx
@@ -4,6 +4,8 @@ import { getDictionary } from '@/i18n/get-dictionary';
 import type { Locale } from '@/i18n/config';
 import { fetchCategories } from '@/repo/categories/fetch';
 import { queryKeys } from '@/repo/keys';
+import { buildPageMetadata } from '@/lib/seo/metadata';
+import { buildKeywords, flattenKeywords } from '@/lib/seo/keywords';
 import NewPostClient from './NewPostClient';
 
 export const dynamic = 'force-dynamic';
@@ -40,14 +42,23 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
     };
   })();
 
-  return {
-    title: t.title || fallback.title,
-    description: t.description || fallback.description,
+  const meta = (dict?.metadata as Record<string, unknown>) || {};
+  const title = t.title || fallback.title;
+  const description = t.description || fallback.description;
+  const keywords = flattenKeywords(buildKeywords({ title, content: description }));
+
+  return buildPageMetadata({
+    locale: lang,
+    path: '/posts/new',
+    title,
+    description,
+    siteName: (meta?.home as Record<string, string>)?.siteName,
+    keywords,
     robots: {
       index: false,
       follow: false,
     },
-  };
+  });
 }
 
 export default async function NewPostPage({ params }: PageProps) {

--- a/src/app/[lang]/(main)/privacy/page.tsx
+++ b/src/app/[lang]/(main)/privacy/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
 import MainLayout from '@/components/templates/MainLayout';
 import { getDictionary } from '@/i18n/get-dictionary';
-import { i18n, type Locale } from '@/i18n/config';
-import { SITE_URL } from '@/lib/siteUrl';
+import { type Locale } from '@/i18n/config';
+import { buildPageMetadata } from '@/lib/seo/metadata';
+import { buildKeywords, flattenKeywords } from '@/lib/seo/keywords';
 
 type PageProps = {
   params: Promise<{ lang: Locale }>;
@@ -12,33 +13,34 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { lang } = await params;
   const dict = await getDictionary(lang);
   const meta = dict.metadata as Record<string, any>;
-  const baseUrl = SITE_URL;
-  const currentUrl = `${baseUrl}/${lang}/privacy`;
+  const title =
+    meta.privacy?.title ||
+    (lang === 'en'
+      ? 'Privacy - viet kconnect'
+      : lang === 'vi'
+        ? 'Quyền riêng tư - viet kconnect'
+        : '개인정보처리방침 - viet kconnect');
+  const description =
+    meta.privacy?.description ||
+    (lang === 'en'
+      ? 'Learn how viet kconnect handles your data.'
+      : lang === 'vi'
+        ? 'Tìm hiểu cách viet kconnect xử lý dữ liệu của bạn.'
+        : 'viet kconnect의 개인정보 처리 방침을 확인하세요.');
+  const keywords = flattenKeywords(buildKeywords({ title, content: description }));
 
-  return {
-    title:
-      meta.privacy?.title ||
-      (lang === 'en'
-        ? 'Privacy - viet kconnect'
-        : lang === 'vi'
-          ? 'Quyền riêng tư - viet kconnect'
-          : '개인정보처리방침 - viet kconnect'),
-    description:
-      meta.privacy?.description ||
-      (lang === 'en'
-        ? 'Learn how viet kconnect handles your data.'
-        : lang === 'vi'
-          ? 'Tìm hiểu cách viet kconnect xử lý dữ liệu của bạn.'
-          : 'viet kconnect의 개인정보 처리 방침을 확인하세요.'),
-    alternates: {
-      canonical: currentUrl,
-      languages: Object.fromEntries(i18n.locales.map((l) => [l, `${baseUrl}/${l}/privacy`])),
-    },
+  return buildPageMetadata({
+    locale: lang,
+    path: '/privacy',
+    title,
+    description,
+    siteName: (meta?.home as Record<string, string>)?.siteName,
+    keywords,
     robots: {
       index: true,
       follow: true,
     },
-  };
+  });
 }
 
 export default async function PrivacyPage({ params }: PageProps) {

--- a/src/app/[lang]/(main)/subscriptions/page.tsx
+++ b/src/app/[lang]/(main)/subscriptions/page.tsx
@@ -2,6 +2,8 @@ import { Metadata } from 'next';
 import { getDictionary } from '@/i18n/get-dictionary';
 import type { Locale } from '@/i18n/config';
 import MainLayout from '@/components/templates/MainLayout';
+import { buildPageMetadata } from '@/lib/seo/metadata';
+import { buildKeywords, flattenKeywords } from '@/lib/seo/keywords';
 import SubscriptionsClient from './SubscriptionsClient';
 
 export const dynamic = 'force-dynamic';
@@ -19,15 +21,21 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 
   const title = t.title || 'Subscription settings';
   const description = t.description || 'Manage the categories and topics you follow.';
+  const meta = (dict?.metadata as Record<string, unknown>) || {};
+  const keywords = flattenKeywords(buildKeywords({ title, content: description }));
 
-  return {
+  return buildPageMetadata({
+    locale: lang,
+    path: '/subscriptions',
     title,
     description,
+    siteName: (meta?.home as Record<string, string>)?.siteName,
+    keywords,
     robots: {
       index: false,
       follow: false,
     },
-  };
+  });
 }
 
 export default async function SubscriptionsPage({ params }: PageProps) {

--- a/src/app/[lang]/(main)/terms/page.tsx
+++ b/src/app/[lang]/(main)/terms/page.tsx
@@ -1,8 +1,9 @@
 import type { Metadata } from 'next';
 import MainLayout from '@/components/templates/MainLayout';
 import { getDictionary } from '@/i18n/get-dictionary';
-import { i18n, type Locale } from '@/i18n/config';
-import { SITE_URL } from '@/lib/siteUrl';
+import { type Locale } from '@/i18n/config';
+import { buildPageMetadata } from '@/lib/seo/metadata';
+import { buildKeywords, flattenKeywords } from '@/lib/seo/keywords';
 
 type PageProps = {
   params: Promise<{ lang: Locale }>;
@@ -12,33 +13,34 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const { lang } = await params;
   const dict = await getDictionary(lang);
   const meta = dict.metadata as Record<string, any>;
-  const baseUrl = SITE_URL;
-  const currentUrl = `${baseUrl}/${lang}/terms`;
+  const title =
+    meta.terms?.title ||
+    (lang === 'en'
+      ? 'Terms - viet kconnect'
+      : lang === 'vi'
+        ? 'Điều khoản - viet kconnect'
+        : '이용약관 - viet kconnect');
+  const description =
+    meta.terms?.description ||
+    (lang === 'en'
+      ? 'Review the terms of service for viet kconnect.'
+      : lang === 'vi'
+        ? 'Xem điều khoản dịch vụ của viet kconnect.'
+        : 'viet kconnect 이용약관을 확인하세요.');
+  const keywords = flattenKeywords(buildKeywords({ title, content: description }));
 
-  return {
-    title:
-      meta.terms?.title ||
-      (lang === 'en'
-        ? 'Terms - viet kconnect'
-        : lang === 'vi'
-          ? 'Điều khoản - viet kconnect'
-          : '이용약관 - viet kconnect'),
-    description:
-      meta.terms?.description ||
-      (lang === 'en'
-        ? 'Review the terms of service for viet kconnect.'
-        : lang === 'vi'
-          ? 'Xem điều khoản dịch vụ của viet kconnect.'
-          : 'viet kconnect 이용약관을 확인하세요.'),
-    alternates: {
-      canonical: currentUrl,
-      languages: Object.fromEntries(i18n.locales.map((l) => [l, `${baseUrl}/${l}/terms`])),
-    },
+  return buildPageMetadata({
+    locale: lang,
+    path: '/terms',
+    title,
+    description,
+    siteName: (meta?.home as Record<string, string>)?.siteName,
+    keywords,
     robots: {
       index: true,
       follow: true,
     },
-  };
+  });
 }
 
 export default async function TermsPage({ params }: PageProps) {

--- a/src/app/[lang]/guide/trust-badges/page.tsx
+++ b/src/app/[lang]/guide/trust-badges/page.tsx
@@ -3,6 +3,8 @@ import { notFound } from 'next/navigation';
 import TrustBadge, { type TrustLevel } from '@/components/atoms/TrustBadge';
 import { getDictionary } from '@/i18n/get-dictionary';
 import { i18n, type Locale } from '@/i18n/config';
+import { buildPageMetadata } from '@/lib/seo/metadata';
+import { buildKeywords, flattenKeywords } from '@/lib/seo/keywords';
 
 type PageProps = {
   params: Promise<{ lang: string }>;
@@ -34,10 +36,16 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
         ? 'Tìm hiểu ý nghĩa của từng huy hiệu tin cậy và cách được gán.'
         : '각 신뢰 배지의 의미와 부여 기준을 확인하세요.');
 
-  return {
+  const keywords = flattenKeywords(buildKeywords({ title, content: description }));
+
+  return buildPageMetadata({
+    locale,
+    path: '/guide/trust-badges',
     title,
     description,
-  };
+    siteName: (meta?.home as Record<string, string>)?.siteName,
+    keywords,
+  });
 }
 
 export default async function TrustBadgesGuidePage({ params }: PageProps) {
@@ -179,4 +187,3 @@ export default async function TrustBadgesGuidePage({ params }: PageProps) {
     </main>
   );
 }
-


### PR DESCRIPTION
@codex please review

- why: 정적/유틸 페이지 메타 생성 로직을 단일 빌더로 통일
- what: about/faq/privacy/terms/feedback/notifications/posts/new/subscriptions/guide(trust-badges) 메타를 buildPageMetadata + buildKeywords로 이관, 작업 기록 갱신
- test: npm run lint
