### PR TITLE
P0: mobile UX tweaks (follow modal, PostCard hide, editor links)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -159,6 +159,23 @@
   background: #1f2937;
 }
 
+.ProseMirror a {
+  color: #2563eb;
+  text-decoration: underline;
+}
+
+.dark .ProseMirror a {
+  color: #60a5fa;
+}
+
+.ProseMirror a:hover {
+  color: #1d4ed8;
+}
+
+.dark .ProseMirror a:hover {
+  color: #93c5fd;
+}
+
 /* Prose/UGC Content Styles */
 .prose h1 {
   font-size: 2em;

--- a/src/components/molecules/cards/PostCard.tsx
+++ b/src/components/molecules/cards/PostCard.tsx
@@ -506,16 +506,6 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
         className={`question-card group relative ${isQuestion ? 'question-card--question' : ''} ${hasMedia ? 'question-card--with-media' : ''} ${isAdopted ? 'border-green-400 ring-1 ring-green-200 dark:ring-emerald-600/50' : ''
           }`}
       >
-        <Tooltip content={hideLabel} position="left" touchBehavior="longPress">
-          <button
-            type="button"
-            onClick={handleToggleHide}
-            aria-label={hideLabel}
-            className="absolute top-3 right-3 z-10 flex h-7 w-7 items-center justify-center text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
-          >
-            <span aria-hidden className="text-base leading-none">×</span>
-          </button>
-        </Tooltip>
 		        <div className="question-card-main">
 		          <div className="question-card-body">
 		          <div className="flex items-start gap-2 mb-3 min-w-0">
@@ -569,11 +559,21 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
                 <div className="flex flex-wrap items-center gap-2 text-[11px] text-gray-500 dark:text-gray-400">
 	                  <span>{formatDateTime(publishedAt, locale)}</span>
 	                </div>
-	              </div>
-	            </div>
-		          </div>
-	
-	          <div className="min-w-0">
+		              </div>
+		            </div>
+                <Tooltip content={hideLabel} position="left" touchBehavior="longPress">
+                  <button
+                    type="button"
+                    onClick={handleToggleHide}
+                    aria-label={hideLabel}
+                    className="mt-1 flex h-6 w-6 items-center justify-center text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 transition-colors"
+                  >
+                    <span aria-hidden className="text-sm leading-none">×</span>
+                  </button>
+                </Tooltip>
+			          </div>
+		
+		          <div className="min-w-0">
 	            <div className="flex flex-wrap items-center gap-2 mb-2 min-w-0">
               <h3 className="text-[19px] font-bold leading-snug text-gray-900 dark:text-gray-100 transition-colors group-hover:opacity-90">
                 {title}

--- a/src/components/molecules/modals/FollowingModal.tsx
+++ b/src/components/molecules/modals/FollowingModal.tsx
@@ -341,19 +341,14 @@ export default function FollowingModal({ isOpen, onClose, translations = {} }: F
         key={userItem.id}
         className="bg-white dark:bg-gray-800 rounded-xl p-4 hover:shadow-lg transition-all border border-gray-200 dark:border-gray-700"
       >
-        <div className="flex items-start gap-4">
-          <div className="flex flex-col items-center gap-2">
-            <Avatar
-              name={displayName}
-              imageUrl={userItem.avatar || userItem.image}
-              size="lg"
-              hoverHighlight
-            />
+        <div className="flex items-start gap-3">
+          <div className="flex items-center gap-2 shrink-0">
+            <Avatar name={displayName} imageUrl={userItem.avatar || userItem.image} size="xl" hoverHighlight />
             <FollowButton
               userId={String(userItem.id)}
               userName={displayName}
               isFollowing={isFollowing}
-              size="sm"
+              size="xs"
               translations={translations}
               onToggle={(next) =>
                 setFollowStates((prev) => ({
@@ -364,7 +359,7 @@ export default function FollowingModal({ isOpen, onClose, translations = {} }: F
             />
           </div>
 
-          <div className="flex-1 min-w-0">
+          <div className="flex-1 min-w-0 pt-0.5">
             <button
               type="button"
               onClick={() => handleUserClick(userItem.id)}
@@ -406,7 +401,7 @@ export default function FollowingModal({ isOpen, onClose, translations = {} }: F
                 if (!effectiveUserType) return null;
                 return (
                   <span className="inline-block px-2 py-0.5 text-xs bg-blue-100 dark:bg-blue-900/30 text-blue-700 dark:text-blue-300 rounded-full mb-2">
-                    #{getUserTypeLabel(effectiveUserType, userTypeLabels)}
+                    {getUserTypeLabel(effectiveUserType, userTypeLabels)}
                   </span>
                 );
               })()}
@@ -415,13 +410,22 @@ export default function FollowingModal({ isOpen, onClose, translations = {} }: F
                   {userItem.bio}
                 </p>
               )}
-              <div className="text-xs text-gray-500 dark:text-gray-400 flex flex-wrap gap-1">
-                {metaTexts.map((text, index) => (
-                  <span key={`${userItem.id}-meta-${index}`} className="inline-flex">
-                    # {text}
-                  </span>
-                ))}
-              </div>
+              {metaTexts.length > 0 ? (
+                <div className="flex flex-wrap gap-1.5 text-[11px] text-gray-600 dark:text-gray-300">
+                  {metaTexts.slice(0, 3).map((text, index) => (
+                    <span
+                      key={`${userItem.id}-meta-${index}`}
+                      className={`inline-flex items-center rounded-full px-2 py-0.5 ${
+                        index === 0
+                          ? 'bg-blue-50 text-blue-700 dark:bg-blue-900/30 dark:text-blue-200'
+                          : 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-200'
+                      }`}
+                    >
+                      {text}
+                    </span>
+                  ))}
+                </div>
+              ) : null}
             </button>
           </div>
         </div>


### PR DESCRIPTION
@codex\n\n- FollowingModal: recommended/following user cards show larger avatar + smaller follow CTA, and meta pills (max 3) without # spam.\n- PostCard: move hide(×) into header row for consistent placement regardless of media.\n- Editor: add ProseMirror link styling so inserted links are visible.\n\nValidation: npm run lint, npm run type-check, SKIP_SITEMAP_DB=true npm run build, npm run test:e2e