### PR TITLE
[UI] Align header layout and sidebar sheet close

### DIFF
--- a/src/components/organisms/CategorySidebar.tsx
+++ b/src/components/organisms/CategorySidebar.tsx
@@ -258,7 +258,7 @@ export default function CategorySidebar({
               : 'pb-4 border-b border-gray-200/40 dark:border-gray-700/40'
           }
         >
-          <div className={isMobileVariant ? 'flex items-center justify-between px-4 pb-2' : ''}>
+          <div className={isMobileVariant ? 'flex items-center gap-2 px-4 pb-2' : ''}>
             {isMobileVariant ? (
               <button
                 type="button"

--- a/src/components/organisms/Header.tsx
+++ b/src/components/organisms/Header.tsx
@@ -91,7 +91,7 @@ export default function Header({ isMobileMenuOpen, setIsMobileMenuOpen, showBack
         }
         text-gray-900 dark:text-white`}
     >
-      <div className="mx-auto grid w-full max-w-[1680px] h-[var(--vk-header-height)] grid-cols-[auto_minmax(0,1fr)_auto] lg:grid-cols-[320px_minmax(0,1fr)_320px] 2xl:grid-cols-[320px_minmax(0,960px)_320px] 2xl:justify-center items-center gap-2 px-2 sm:px-3 lg:px-4">
+      <div className="mx-auto grid w-full max-w-[1680px] h-[var(--vk-header-height)] grid-cols-[auto_minmax(0,1fr)_auto] lg:grid-cols-[320px_minmax(0,1fr)_320px] 2xl:grid-cols-[320px_minmax(0,920px)_320px] 2xl:justify-center items-center gap-2 px-4 sm:px-6 lg:px-8">
         <div className="flex items-center gap-1.5 sm:gap-3 min-w-0 justify-self-start">
           {showBackButton && (
             <button

--- a/src/components/templates/MainLayout.tsx
+++ b/src/components/templates/MainLayout.tsx
@@ -65,7 +65,7 @@ export default function MainLayout({ children, selectedCategory = 'all', onCateg
                 />
               </aside>
 	              <Sheet open={isMobileMenuOpen} onOpenChange={setIsMobileMenuOpen}>
-	                <SheetContent side="left" className="p-0 w-[320px] sm:w-[360px] max-w-[85vw]">
+	                <SheetContent side="left" showCloseButton={false} className="p-0 w-[320px] sm:w-[360px] max-w-[85vw]">
 	                  <CategorySidebar
 	                    variant="mobile"
 	                    setIsMobileMenuOpen={setIsMobileMenuOpen}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -48,9 +48,11 @@ function SheetContent({
   className,
   children,
   side = "right",
+  showCloseButton = true,
   ...props
 }: React.ComponentProps<typeof SheetPrimitive.Content> & {
   side?: "top" | "right" | "bottom" | "left"
+  showCloseButton?: boolean
 }) {
   const closePositionClass =
     side === "left" ? "top-4 left-4 right-auto" : "top-4 right-4";
@@ -74,15 +76,17 @@ function SheetContent({
         {...props}
       >
         {children}
-        <SheetPrimitive.Close
-          className={cn(
-            "ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none",
-            closePositionClass
-          )}
-        >
-          <XIcon className="size-4" />
-          <span className="sr-only">Close</span>
-        </SheetPrimitive.Close>
+        {showCloseButton ? (
+          <SheetPrimitive.Close
+            className={cn(
+              "ring-offset-background focus:ring-ring data-[state=open]:bg-secondary absolute rounded-xs opacity-70 transition-opacity hover:opacity-100 focus:ring-2 focus:ring-offset-2 focus:outline-hidden disabled:pointer-events-none",
+              closePositionClass
+            )}
+          >
+            <XIcon className="size-4" />
+            <span className="sr-only">Close</span>
+          </SheetPrimitive.Close>
+        ) : null}
       </SheetPrimitive.Content>
     </SheetPortal>
   )


### PR DESCRIPTION
@codex please review.

- Disable default Sheet close button for main mobile sidebar (use sidebar header close).
- Align Header grid/padding with MainLayout (2xl center 920px).

Tests:
- npm run lint
- npm run type-check
- SKIP_SITEMAP_DB=true npm run build
- npm run test:e2e