### PR TITLE
[UI] Stabilize PostCard hide button position

### DIFF
--- a/src/components/molecules/cards/PostCard.tsx
+++ b/src/components/molecules/cards/PostCard.tsx
@@ -506,16 +506,6 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
         className={`question-card group relative ${isQuestion ? 'question-card--question' : ''} ${hasMedia ? 'question-card--with-media' : ''} ${isAdopted ? 'border-green-400 ring-1 ring-green-200 dark:ring-emerald-600/50' : ''
           }`}
       >
-        <Tooltip content={hideLabel} position="left" touchBehavior="longPress">
-          <button
-            type="button"
-            onClick={handleToggleHide}
-            aria-label={hideLabel}
-            className="sm:hidden absolute top-3 right-3 z-10 flex h-6 w-6 items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
-          >
-            <span aria-hidden className="text-base leading-none">×</span>
-          </button>
-        </Tooltip>
 		        <div className="question-card-main">
 			          <div className="question-card-body relative">
 			          <div className="flex items-start gap-2 mb-3 min-w-0">
@@ -576,7 +566,7 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
 			                type="button"
 			                onClick={handleToggleHide}
 			                aria-label={hideLabel}
-			                className="hidden sm:flex shrink-0 mt-0.5 h-6 w-6 items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+			                className="flex shrink-0 mt-0.5 h-7 w-7 sm:h-6 sm:w-6 items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
 			              >
 			                <span aria-hidden className="text-base leading-none">×</span>
 			              </button>


### PR DESCRIPTION
@codex please review.

- Move PostCard hide(×) control into the author row so it stays consistent regardless of thumbnail presence.

Tests:
- npm run lint
- npm run type-check
- SKIP_SITEMAP_DB=true npm run build
- npm run test:e2e