### PR TITLE
[UI] Improve mobile rails and recommended users carousel

### DIFF
--- a/src/components/organisms/PostList.tsx
+++ b/src/components/organisms/PostList.tsx
@@ -305,7 +305,7 @@ export default function PostList({ selectedCategory = 'all', isSearchMode = fals
     <div className="pt-0 pb-4">
       {selectedCategory === 'subscribed' && topicSubscriptions.length > 0 ? (
         <div className="mb-4">
-          <div className="flex items-center gap-1.5 overflow-x-auto scrollbar-hide py-0.5 px-3 pr-6 scroll-px-3">
+          <div className="flex items-center gap-1.5 overflow-x-auto scrollbar-hide py-0.5 px-3 pr-10 scroll-px-3">
             <button
               type="button"
               onClick={() => handleSubscribedCategoryChange('all')}

--- a/src/components/organisms/RecommendedUsersSection.tsx
+++ b/src/components/organisms/RecommendedUsersSection.tsx
@@ -318,7 +318,7 @@ export default function RecommendedUsersSection({
         onScroll={markInteracted}
         className={`grid grid-flow-col ${
           compact
-            ? 'auto-cols-[minmax(340px,1fr)] sm:auto-cols-[minmax(380px,1fr)]'
+            ? 'auto-cols-[minmax(320px,calc(100vw-4.5rem))] sm:auto-cols-[minmax(380px,1fr)]'
             : 'auto-cols-[minmax(260px,1fr)] sm:auto-cols-[minmax(320px,1fr)]'
         } lg:auto-cols-[minmax(280px,1fr)] ${compact ? 'gap-2' : 'gap-3'} overflow-x-auto scrollbar-hide snap-x snap-mandatory pb-1 pr-3 scroll-px-3`}
       >


### PR DESCRIPTION
@codex please review.

- Subscribed-topic chip row: add right padding to avoid last chip being clipped.
- Recommended users carousel (compact): widen auto-column sizing to better fit mobile widths and reduce truncation.

Tests:
- npm run lint
- npm run type-check
- SKIP_SITEMAP_DB=true npm run build
- npm run test:e2e