### PR TITLE
[P0] error codes for i18n

### DIFF
--- a/messages/ko.json
+++ b/messages/ko.json
@@ -1064,6 +1064,10 @@
     "outdatedTooltip": "12개월 이상 지난 정보"
   },
   "errors": {
+    "UNAUTHORIZED": "로그인이 필요합니다.",
+    "FORBIDDEN": "권한이 없습니다.",
+    "NOT_FOUND": "요청한 정보를 찾을 수 없습니다.",
+    "SERVER_ERROR": "서버 오류가 발생했습니다.",
     "POST_REQUIRED_FIELDS": "제목, 카테고리(대분류/세부분류), 내용을 모두 입력해주세요.",
     "POST_INVALID_CATEGORY": "대분류를 다시 선택해주세요.",
     "POST_SUBCATEGORY_REQUIRED": "세부분류를 선택해주세요.",
@@ -1094,6 +1098,7 @@
     "COMMENT_RATE_LIMITED": "댓글 작성 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
     "REPORT_TYPE_REQUIRED": "신고 유형을 선택해주세요.",
     "REPORT_INVALID_TYPE": "올바르지 않은 신고 유형입니다.",
+    "REPORT_REQUIRED_FIELDS": "필수 정보가 누락되었습니다.",
     "REPORT_REASON_TOO_SHORT": "기타 신고 시 사유를 10자 이상 입력해주세요.",
     "REPORT_TARGET_NOT_FOUND": "대상을 찾을 수 없습니다.",
     "REPORT_SELF_FORBIDDEN": "본인의 콘텐츠는 신고할 수 없습니다.",
@@ -1102,6 +1107,9 @@
     "REPORT_FAILED": "신고에 실패했습니다.",
     "FEEDBACK_FAILED": "피드백 제출에 실패했습니다.",
     "FEEDBACK_RATE_LIMITED": "피드백 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
+    "HIDE_INVALID_TARGET_TYPE": "올바르지 않은 대상입니다.",
+    "HIDE_REQUIRED_FIELDS": "필수 정보가 누락되었습니다.",
+    "PROFILE_DISPLAY_NAME_TOO_SHORT": "닉네임은 2자 이상이어야 합니다.",
     "VERIFICATION_RATE_LIMITED": "인증 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.",
     "PROBE_RATE_LIMITED": "요청이 너무 많습니다. 잠시 후 다시 시도해주세요."
   }

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -1064,6 +1064,10 @@
     "outdatedTooltip": "Thông tin hơn 12 tháng trước"
   },
   "errors": {
+    "UNAUTHORIZED": "Vui lòng đăng nhập.",
+    "FORBIDDEN": "Bạn không có quyền thực hiện thao tác này.",
+    "NOT_FOUND": "Không tìm thấy dữ liệu yêu cầu.",
+    "SERVER_ERROR": "Đã xảy ra lỗi máy chủ.",
     "POST_REQUIRED_FIELDS": "Vui lòng nhập tiêu đề, danh mục (chính/phụ) và nội dung.",
     "POST_INVALID_CATEGORY": "Vui lòng chọn lại danh mục chính.",
     "POST_SUBCATEGORY_REQUIRED": "Vui lòng chọn danh mục phụ.",
@@ -1094,6 +1098,7 @@
     "COMMENT_RATE_LIMITED": "Bạn bình luận quá nhiều lần. Vui lòng thử lại sau.",
     "REPORT_TYPE_REQUIRED": "Vui lòng chọn loại báo cáo.",
     "REPORT_INVALID_TYPE": "Loại báo cáo không hợp lệ.",
+    "REPORT_REQUIRED_FIELDS": "Thiếu thông tin bắt buộc.",
     "REPORT_REASON_TOO_SHORT": "Vui lòng nhập lý do ít nhất 10 ký tự.",
     "REPORT_TARGET_NOT_FOUND": "Không tìm thấy nội dung.",
     "REPORT_SELF_FORBIDDEN": "Bạn không thể báo cáo nội dung của chính mình.",
@@ -1102,6 +1107,9 @@
     "REPORT_FAILED": "Không thể gửi báo cáo.",
     "FEEDBACK_FAILED": "Gửi phản hồi thất bại.",
     "FEEDBACK_RATE_LIMITED": "Bạn gửi phản hồi quá nhiều lần. Vui lòng thử lại sau.",
+    "HIDE_INVALID_TARGET_TYPE": "Đối tượng không hợp lệ.",
+    "HIDE_REQUIRED_FIELDS": "Thiếu thông tin bắt buộc.",
+    "PROFILE_DISPLAY_NAME_TOO_SHORT": "Biệt danh phải có ít nhất 2 ký tự.",
     "VERIFICATION_RATE_LIMITED": "Bạn gửi yêu cầu xác minh quá nhiều lần. Vui lòng thử lại sau.",
     "PROBE_RATE_LIMITED": "Bạn gửi quá nhiều yêu cầu. Vui lòng thử lại sau."
   }

--- a/src/app/api/hides/route.ts
+++ b/src/app/api/hides/route.ts
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
     const typeParam = request.nextUrl.searchParams.get('type');
     const targetType = parseTargetType(typeParam);
     if (typeParam && !targetType) {
-      return errorResponse('올바르지 않은 대상입니다.');
+      return errorResponse('올바르지 않은 대상입니다.', 'HIDE_INVALID_TARGET_TYPE');
     }
 
     const rows = await db
@@ -58,7 +58,7 @@ export async function POST(request: NextRequest) {
     const targetId = typeof body?.targetId === 'string' ? body.targetId : '';
 
     if (!targetType || !targetId) {
-      return errorResponse('필수 필드가 누락되었습니다.');
+      return errorResponse('필수 필드가 누락되었습니다.', 'HIDE_REQUIRED_FIELDS');
     }
 
     let exists = false;
@@ -108,7 +108,7 @@ export async function DELETE(request: NextRequest) {
     const targetId = typeof body?.targetId === 'string' ? body.targetId : '';
 
     if (!targetType || !targetId) {
-      return errorResponse('필수 필드가 누락되었습니다.');
+      return errorResponse('필수 필드가 누락되었습니다.', 'HIDE_REQUIRED_FIELDS');
     }
 
     await db.delete(contentReports).where(

--- a/src/app/api/reports/route.ts
+++ b/src/app/api/reports/route.ts
@@ -22,7 +22,7 @@ export async function POST(request: NextRequest) {
     };
 
     if (!targetType || !targetId || !type || !reason) {
-      return errorResponse('필수 필드가 누락되었습니다.');
+      return errorResponse('필수 필드가 누락되었습니다.', 'REPORT_REQUIRED_FIELDS');
     }
 
     const rateLimit = await checkRateLimit({
@@ -43,11 +43,11 @@ export async function POST(request: NextRequest) {
 
     const validTypes = ['spam', 'harassment', 'inappropriate', 'misinformation', 'other'] as const;
     if (!validTypes.includes(type)) {
-      return errorResponse('올바르지 않은 신고 유형입니다.');
+      return errorResponse('올바르지 않은 신고 유형입니다.', 'REPORT_INVALID_TYPE');
     }
 
     if (type === 'other' && reason.trim().length < 10) {
-      return errorResponse('기타 신고 시 사유를 10자 이상 입력해주세요.');
+      return errorResponse('기타 신고 시 사유를 10자 이상 입력해주세요.', 'REPORT_REASON_TOO_SHORT');
     }
 
     const trimmedReason = reason.trim();
@@ -70,7 +70,7 @@ export async function POST(request: NextRequest) {
     }
 
     if (exists.authorId === user.id) {
-      return errorResponse('본인의 콘텐츠는 신고할 수 없습니다.');
+      return errorResponse('본인의 콘텐츠는 신고할 수 없습니다.', 'REPORT_SELF_FORBIDDEN');
     }
 
     const dup =

--- a/src/app/api/users/me/route.ts
+++ b/src/app/api/users/me/route.ts
@@ -168,7 +168,7 @@ export async function PUT(request: NextRequest) {
     if (displayName !== undefined) {
       const normalized = normalizeDisplayName(displayName);
       if (normalized.length < DISPLAY_NAME_MIN_LENGTH) {
-        return errorResponse('닉네임은 2자 이상이어야 합니다.');
+        return errorResponse('닉네임은 2자 이상이어야 합니다.', 'PROFILE_DISPLAY_NAME_TOO_SHORT');
       }
       updateData.displayName = normalized;
       updateData.name = normalized;


### PR DESCRIPTION
@codex

- Add explicit error codes for routes that previously returned only Korean error strings (/api/hides, /api/users/me, /api/reports).
- Add ko/vi translations for common codes (UNAUTHORIZED/FORBIDDEN/NOT_FOUND/SERVER_ERROR) and new codes.

Tests:
- npm run lint
- npm run type-check
- SKIP_SITEMAP_DB=true npm run build
- npm run test:e2e
