### PR TITLE
[P0] Signup/Profile/SimilarPrompt i18n sweep (P0-2)

### DIFF
--- a/docs/WORKING_PLAN.md
+++ b/docs/WORKING_PLAN.md
@@ -2823,3 +2823,17 @@ $gh-address-comments
   - [x] `npm run type-check`
   - [x] `SKIP_SITEMAP_DB=true npm run build`
   - [x] `npm run test:e2e`
+
+#### (2025-12-23) [P0] Signup/프로필/유사질문 i18n 하드코딩 제거 + signup update API 정합 (P0-2)
+
+- 목표: 회원가입(프로필 완성)에서 하드코딩(`국내/해외`) 제거 + 프로필 날짜 표시의 하드코딩 제거 + 유사질문 추천태그 locale 분기 제거 + 회원가입 프로필 업데이트 API 경로/메서드 정합
+- 변경 내용
+  - `src/app/[lang]/(auth)/signup/SignupClient.tsx`: nationality value를 code(`domestic/overseas`)로 전환 + 프로필 업데이트를 `PUT /api/users/[id]`로 정합
+  - `src/app/[lang]/(main)/profile/[id]/ProfileClient.tsx`: `방금 전` 비교 하드코딩 제거 → `getJustNowLabel(locale)` 사용
+  - `src/components/organisms/SimilarQuestionPrompt.tsx`: 추천 태그를 messages(`newPost.similarTagSuggestions`) 기반으로 파싱(코드 내 locale 분기 제거)
+  - `messages/ko.json`, `messages/vi.json`: `newPost.similarTagSuggestions` 추가
+- 검증
+  - [x] `npm run lint`
+  - [x] `npm run type-check`
+  - [x] `SKIP_SITEMAP_DB=true npm run build`
+  - [x] `npm run test:e2e`

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -771,6 +771,7 @@
     "similarDesc": "질문을 작성하기 전에 비슷한 답변을 확인해보세요.",
     "similarSeeAll": "모두 보기",
     "similarTagsLabel": "추천 태그",
+    "similarTagSuggestions": "비자,취업,주거",
     "similarFallbackNotice": "비슷한 질문이 아직 없어서 인기 질문을 보여드려요.",
     "similarFallbackReasonPopular": "최근 많은 조회를 받은 질문을 먼저 확인해보세요.",
     "similarFallbackTokensLabel": "검색 키워드",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -771,6 +771,7 @@
     "similarDesc": "Xem câu trả lời tương tự trước khi đăng câu hỏi.",
     "similarSeeAll": "Xem tất cả",
     "similarTagsLabel": "Thẻ gợi ý",
+    "similarTagSuggestions": "Visa,Việc làm,Nhà ở",
     "similarFallbackNotice": "Chưa có câu hỏi tương tự nên đang hiển thị bài viết phổ biến.",
     "similarFallbackReasonPopular": "Đây là các chủ đề được cộng đồng quan tâm nhiều nhất.",
     "similarFallbackTokensLabel": "Từ khóa tìm kiếm",

--- a/src/app/[lang]/(auth)/signup/SignupClient.tsx
+++ b/src/app/[lang]/(auth)/signup/SignupClient.tsx
@@ -21,7 +21,7 @@ export default function SignupClient({ lang, translations }: SignupClientProps) 
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [formData, setFormData] = useState({
     nickname: session?.user?.name || '',
-    nationality: '국내',
+    nationality: 'domestic',
     gender: '',
     ageGroup: '',
     userType: '',
@@ -69,10 +69,10 @@ export default function SignupClient({ lang, translations }: SignupClientProps) 
     setIsSubmitting(true);
 
     try {
-      const nationalityLabel = formData.nationality === '해외' ? t.nationalityOverseas || '' : t.nationalityDomestic || '';
+      const nationalityLabel = formData.nationality === 'overseas' ? t.nationalityOverseas || '' : t.nationalityDomestic || '';
 
-      const response = await fetch(`/api/users/${session.user.id}/update`, {
-        method: 'POST',
+      const response = await fetch(`/api/users/${session.user.id}`, {
+        method: 'PUT',
         headers: {
           'Content-Type': 'application/json',
         },
@@ -148,8 +148,8 @@ export default function SignupClient({ lang, translations }: SignupClientProps) 
                   <input
                     type="radio"
                     name="nationality"
-                    value="국내"
-                    checked={formData.nationality === '국내'}
+                    value="domestic"
+                    checked={formData.nationality === 'domestic'}
                     onChange={(e) => setFormData({ ...formData, nationality: e.target.value })}
                     className="w-4 h-4 text-red-600 focus:ring-red-500"
                   />
@@ -159,8 +159,8 @@ export default function SignupClient({ lang, translations }: SignupClientProps) 
                   <input
                     type="radio"
                     name="nationality"
-                    value="해외"
-                    checked={formData.nationality === '해외'}
+                    value="overseas"
+                    checked={formData.nationality === 'overseas'}
                     onChange={(e) => setFormData({ ...formData, nationality: e.target.value })}
                     className="w-4 h-4 text-red-600 focus:ring-red-500"
                   />

--- a/src/app/[lang]/(main)/profile/[id]/ProfileClient.tsx
+++ b/src/app/[lang]/(main)/profile/[id]/ProfileClient.tsx
@@ -17,6 +17,7 @@ import CommentCard from '@/components/molecules/cards/CommentCard';
 import { useInfiniteUserPosts, useInfiniteUserAnswers, useInfiniteUserComments, useInfiniteUserBookmarks, useFollowStatus, useUserScore } from '@/repo/users/query';
 import { getTrustBadgePresentation } from '@/lib/utils/trustBadges';
 import { getUserTypeLabel } from '@/utils/userTypeLabel';
+import { getJustNowLabel } from '@/utils/dateTime';
 
 export interface ProfileData {
   id: string;
@@ -378,7 +379,8 @@ export default function ProfileClient({ initialProfile, locale, translations }: 
   }, [t]);
 
   const formatDate = (dateString: string) => {
-    if (!dateString || dateString === '방금 전') return dateString;
+    const justNowLabel = getJustNowLabel(locale);
+    if (!dateString || dateString === justNowLabel) return dateString;
     const date = dayjs(dateString);
     if (!date.isValid()) return dateString;
     return date.format('YYYY.MM.DD HH:mm');

--- a/src/components/organisms/SimilarQuestionPrompt.tsx
+++ b/src/components/organisms/SimilarQuestionPrompt.tsx
@@ -8,17 +8,18 @@ interface SimilarQuestionPromptProps {
   translations?: Record<string, string>;
 }
 
-const tagSuggestionsByLocale: Record<string, string[]> = {
-  ko: ['비자', '취업', '주거'],
-  vi: ['Visa', 'Việc làm', 'Nhà ở'],
-  en: ['Visa', 'Jobs', 'Housing'],
-};
-
 export default function SimilarQuestionPrompt({ query, translations }: SimilarQuestionPromptProps) {
   const t = translations || {};
   const params = useParams();
   const locale = (params?.lang as string) || 'ko';
-  const tagSuggestions = tagSuggestionsByLocale[locale] || tagSuggestionsByLocale.ko;
+  const tagSuggestions = useMemo(() => {
+    const raw = (t.similarTagSuggestions || '').trim();
+    if (!raw) return [];
+    return raw
+      .split(',')
+      .map((token) => token.trim())
+      .filter((token) => token.length > 0);
+  }, [t.similarTagSuggestions]);
   const visible = (query || '').trim().length >= 3;
   const [results, setResults] = useState<Array<{ id: string; title: string }>>([]);
   const [loading, setLoading] = useState(false);


### PR DESCRIPTION
@codex\n\nP0-2 i18n/클립 스윕 일부 + signup 프로필 업데이트 API 정합.\n\n- Signup: nationality 하드코딩 제거(domestic/overseas) + PUT /api/users/[id]로 정합\n- Profile: '방금 전' 하드코딩 제거(getJustNowLabel(locale))\n- SimilarQuestionPrompt: 추천 태그 locale 분기 제거 → messages 기반 CSV 파싱\n\n검증: lint/type-check/build/test:e2e(로컬)