### PR TITLE
[P0] i18n: trust badges + ShareButton (P0-2)

### DIFF
--- a/docs/WORKING_PLAN.md
+++ b/docs/WORKING_PLAN.md
@@ -2837,3 +2837,17 @@ $gh-address-comments
   - [x] `npm run type-check`
   - [x] `SKIP_SITEMAP_DB=true npm run build`
   - [x] `npm run test:e2e`
+
+#### (2025-12-23) [P0] Trust badges/ShareButton 하드코딩 제거 (P0-2)
+
+- 목표: Trust badges 가이드/ShareButton에 남아있던 locale 분기 하드코딩을 제거하고 messages 기반으로 단일화
+- 변경 내용
+  - `src/app/[lang]/guide/trust-badges/page.tsx`: 메타(title/description) 및 헤딩/서브헤딩을 messages 기반으로 통일
+  - `messages/ko.json`, `messages/vi.json`, `messages/en.json`: `metadata.trustBadges` + `trustBadges.guideTitle/guideSubtitle` 추가
+  - `src/components/molecules/actions/ShareButton.tsx`: locale 하드코딩 제거 + `translations` 기반 tooltip/linkCopied 사용
+  - `src/components/organisms/CardNewsShowcase.tsx`, `src/components/organisms/ShortFormPlaylist.tsx`: ShareButton에 `translations` 전달
+- 검증
+  - [x] `npm run lint`
+  - [x] `npm run type-check`
+  - [x] `SKIP_SITEMAP_DB=true npm run build`
+  - [x] `npm run test:e2e`

--- a/messages/en.json
+++ b/messages/en.json
@@ -138,6 +138,10 @@
       "title": "Community Leaderboard - viet kconnect",
       "description": "Discover the most trusted and helpful community members."
     },
+    "trustBadges": {
+      "title": "Trust Badges - viet kconnect",
+      "description": "Learn what each trust badge means and how it is assigned."
+    },
     "about": {
       "title": "About - viet kconnect",
       "description": "Learn what viet kconnect is and how it works."
@@ -923,6 +927,8 @@
     "updateFailed": "Failed to update profile."
   },
   "trustBadges": {
+    "guideTitle": "Trust Badges",
+    "guideSubtitle": "Badges help you quickly judge how trustworthy information is.",
     "verifiedLabel": "Verified",
     "verifiedTooltip": "From a verified user",
     "verifiedStudentLabel": "Verified Student",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -167,6 +167,10 @@
       "title": "커뮤니티 랭킹 - viet kconnect",
       "description": "신뢰도와 기여도가 높은 커뮤니티 멤버를 확인하세요."
     },
+    "trustBadges": {
+      "title": "신뢰 배지 안내 - viet kconnect",
+      "description": "각 신뢰 배지의 의미와 부여 기준을 확인하세요."
+    },
     "about": {
       "title": "소개 - viet kconnect",
       "description": "viet kconnect 소개 및 운영 방식."
@@ -1051,6 +1055,8 @@
     "updateFailed": "프로필 업데이트에 실패했습니다."
   },
   "trustBadges": {
+    "guideTitle": "신뢰 배지 안내",
+    "guideSubtitle": "배지는 정보의 신뢰도를 빠르게 판단하는 데 도움을 줍니다.",
     "verifiedLabel": "검증됨",
     "verifiedTooltip": "인증된 사용자 기반 정보",
     "verifiedStudentLabel": "학생 인증",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -167,6 +167,10 @@
       "title": "Bảng xếp hạng cộng đồng - viet kconnect",
       "description": "Khám phá những thành viên đáng tin và hữu ích nhất trong cộng đồng."
     },
+    "trustBadges": {
+      "title": "Huy hiệu tin cậy - viet kconnect",
+      "description": "Tìm hiểu ý nghĩa của từng huy hiệu tin cậy và cách được gán."
+    },
     "about": {
       "title": "Giới thiệu - viet kconnect",
       "description": "Tìm hiểu về viet kconnect và cách hoạt động."
@@ -1051,6 +1055,8 @@
     "updateFailed": "Không thể cập nhật hồ sơ."
   },
   "trustBadges": {
+    "guideTitle": "Huy hiệu tin cậy",
+    "guideSubtitle": "Huy hiệu giúp bạn nhanh chóng đánh giá mức độ tin cậy của thông tin.",
     "verifiedLabel": "Đã xác minh",
     "verifiedTooltip": "Thông tin từ người dùng đã xác minh",
     "verifiedStudentLabel": "Sinh viên đã xác minh",

--- a/src/app/[lang]/guide/trust-badges/page.tsx
+++ b/src/app/[lang]/guide/trust-badges/page.tsx
@@ -21,24 +21,8 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   const dict = await getDictionary(locale);
   const meta = (dict?.metadata as Record<string, any>) || {};
 
-  const fallbackMetaByLocale = {
-    ko: {
-      title: '신뢰 배지 안내 - viet kconnect',
-      description: '각 신뢰 배지의 의미와 부여 기준을 확인하세요.',
-    },
-    en: {
-      title: 'Trust Badges - viet kconnect',
-      description: 'Learn what each trust badge means and how it is assigned.',
-    },
-    vi: {
-      title: 'Huy hiệu tin cậy - viet kconnect',
-      description: 'Tìm hiểu ý nghĩa của từng huy hiệu tin cậy và cách được gán.',
-    },
-  } as const;
-  const fallbackMeta = fallbackMetaByLocale[locale] || fallbackMetaByLocale.ko;
-
-  const title = meta?.trustBadges?.title || fallbackMeta.title;
-  const description = meta?.trustBadges?.description || fallbackMeta.description;
+  const title = (meta?.trustBadges as Record<string, string> | undefined)?.title || '';
+  const description = (meta?.trustBadges as Record<string, string> | undefined)?.description || '';
 
   const keywords = flattenKeywords(buildKeywords({ title, content: description }));
 
@@ -65,18 +49,8 @@ export default async function TrustBadgesGuidePage({ params }: PageProps) {
   const tBottomNav = (dict?.bottomNav || {}) as Record<string, string>;
   const tSidebar = (dict?.sidebar || {}) as Record<string, string>;
 
-  const headingByLocale = {
-    ko: '신뢰 배지 안내',
-    en: 'Trust Badges',
-    vi: 'Huy hiệu tin cậy',
-  } as const;
-  const subheadingByLocale = {
-    ko: '배지는 정보의 신뢰도를 빠르게 판단하는 데 도움을 줍니다.',
-    en: 'Badges help you quickly judge how trustworthy information is.',
-    vi: 'Huy hiệu giúp bạn nhanh chóng đánh giá mức độ tin cậy của thông tin.',
-  } as const;
-  const heading = headingByLocale[locale] || headingByLocale.ko;
-  const subheading = subheadingByLocale[locale] || subheadingByLocale.ko;
+  const heading = tTrust.guideTitle || '';
+  const subheading = tTrust.guideSubtitle || '';
 
   const homeLabel = tBottomNav.home || '';
   const verifyLabel = tSidebar.verificationRequest || '';
@@ -151,7 +125,6 @@ export default async function TrustBadgesGuidePage({ params }: PageProps) {
       <section className="rounded-2xl border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 p-6">
         <div className="flex items-start justify-between gap-4">
           <div>
-            <p className="text-sm text-gray-500 dark:text-gray-400">Trust</p>
             <h1 className="text-2xl font-bold text-gray-900 dark:text-white">{heading}</h1>
             <p className="mt-2 text-sm text-gray-700 dark:text-gray-200 leading-relaxed">{subheading}</p>
           </div>

--- a/src/components/molecules/actions/ShareButton.tsx
+++ b/src/components/molecules/actions/ShareButton.tsx
@@ -2,7 +2,6 @@
 
 import { useState } from 'react';
 import { Share2, Check } from 'lucide-react';
-import { useParams } from 'next/navigation';
 
 interface ShareButtonProps {
   url?: string;
@@ -10,54 +9,31 @@ interface ShareButtonProps {
   text?: string;
   label?: string;
   className?: string;
+  copiedLabel?: string;
+  translations?: Record<string, unknown>;
 }
 
 export default function ShareButton({
   url,
-  title = 'Viet K-Connect',
+  title,
   text,
   label,
   className = '',
+  copiedLabel,
+  translations,
 }: ShareButtonProps) {
-  const params = useParams();
-  const locale = (params?.lang as string) || 'ko';
-  const resolvedLocale = (['ko', 'en', 'vi'] as const).includes(locale as 'ko' | 'en' | 'vi') ? (locale as 'ko' | 'en' | 'vi') : 'ko';
-  const defaultTextByLocale = {
-    ko: '베트남인을 위한 한국 생활 Q&A 커뮤니티',
-    en: 'Korea life Q&A community for Vietnamese users',
-    vi: 'Cộng đồng hỏi đáp cuộc sống Hàn Quốc cho người Việt',
-  } as const;
-  const buttonLabelsByLocale = {
-    ko: {
-      defaultLabel: '공유',
-      copiedLabel: '복사됨',
-      copyTitle: '링크가 복사되었습니다!',
-      shareTitle: '링크 복사 또는 공유',
-    },
-    en: {
-      defaultLabel: 'Share',
-      copiedLabel: 'Copied',
-      copyTitle: 'Link copied!',
-      shareTitle: 'Copy or share link',
-    },
-    vi: {
-      defaultLabel: 'Chia sẻ',
-      copiedLabel: 'Đã sao chép',
-      copyTitle: 'Liên kết đã được sao chép!',
-      shareTitle: 'Sao chép hoặc chia sẻ liên kết',
-    },
-  } as const;
-  const resolvedLabels = buttonLabelsByLocale[resolvedLocale] || buttonLabelsByLocale.ko;
-  const defaultText = defaultTextByLocale[resolvedLocale] || defaultTextByLocale.ko;
-  const defaultLabel = resolvedLabels.defaultLabel;
-  const copiedLabel = resolvedLabels.copiedLabel;
-  const copyTitle = resolvedLabels.copyTitle;
-  const shareTitleLabel = resolvedLabels.shareTitle;
+  const tTooltips = (translations?.tooltips || {}) as Record<string, string>;
+  const tPostDetail = (translations?.postDetail || {}) as Record<string, string>;
+
+  const resolvedLabel = label || tTooltips.share || '';
+  const resolvedCopiedLabel = copiedLabel || resolvedLabel;
+  const copyTitle = tPostDetail.linkCopied || '';
+  const shareTitleLabel = tTooltips.share || '';
 
   const [copied, setCopied] = useState(false);
   const shareUrl = url || (typeof window !== 'undefined' ? window.location.href : '');
-  const shareTitle = title || (typeof document !== 'undefined' ? document.title : 'Viet K-Connect');
-  const shareText = text || defaultText;
+  const shareTitle = title || (typeof document !== 'undefined' ? document.title : '');
+  const shareText = text || '';
 
   const handleShare = async () => {
     try {
@@ -85,7 +61,7 @@ export default function ShareButton({
       title={copied ? copyTitle : shareTitleLabel}
     >
       {copied ? <Check className="h-4 w-4 text-green-600" /> : <Share2 className="h-4 w-4" />}
-      <span className={copied ? 'text-green-600' : ''}>{copied ? copiedLabel : (label || defaultLabel)}</span>
+      <span className={copied ? 'text-green-600' : ''}>{copied ? resolvedCopiedLabel : resolvedLabel}</span>
     </button>
   );
 }

--- a/src/components/organisms/CardNewsShowcase.tsx
+++ b/src/components/organisms/CardNewsShowcase.tsx
@@ -138,7 +138,7 @@ export default function CardNewsShowcase({ translations, lang }: CardNewsShowcas
                 </button>
                 <div className="flex items-center gap-2 text-[11px] text-gray-500 dark:text-gray-400">
                   <button className="hover:text-gray-800 dark:hover:text-gray-200 transition">{saveLabel}</button>
-                  <ShareButton url={card.linkUrl || undefined} title={card.title} label={shareLabel} className="px-2.5 py-1.5" />
+                  <ShareButton url={card.linkUrl || undefined} title={card.title} label={shareLabel} className="px-2.5 py-1.5" translations={translations} />
                 </div>
               </div>
             </article>

--- a/src/components/organisms/ShortFormPlaylist.tsx
+++ b/src/components/organisms/ShortFormPlaylist.tsx
@@ -122,7 +122,7 @@ export default function ShortFormPlaylist({ translations, lang }: ShortFormPlayl
                   {watch}
                 </button>
                 <button className="hover:text-gray-700 dark:hover:text-gray-200 transition">{save}</button>
-                <ShareButton url={clip.linkUrl || undefined} title={clip.title} label={share} className="px-2.5 py-1.5" />
+                <ShareButton url={clip.linkUrl || undefined} title={clip.title} label={share} className="px-2.5 py-1.5" translations={translations} />
               </div>
             </div>
           </article>


### PR DESCRIPTION
@codex\n\nP0-2 하드코딩 제거 범위 확장(Trust badges/ShareButton).\n\n- Trust badges: meta(title/description) + 헤딩/서브헤딩을 messages 기반으로 통일\n- messages(en/ko/vi): metadata.trustBadges + trustBadges.guideTitle/guideSubtitle 추가\n- ShareButton: locale 하드코딩 제거, translations 기반 tooltip/linkCopied 사용\n- CardNewsShowcase/ShortFormPlaylist: ShareButton에 translations 전달\n\n검증: lint/type-check/build/test:e2e(로컬)