### PR TITLE
[P0] i18n: UserProfile modal loading title (P0-2)

### DIFF
--- a/docs/WORKING_PLAN.md
+++ b/docs/WORKING_PLAN.md
@@ -2851,3 +2851,14 @@ $gh-address-comments
   - [x] `npm run type-check`
   - [x] `SKIP_SITEMAP_DB=true npm run build`
   - [x] `npm run test:e2e`
+
+#### (2025-12-23) [P0] UserProfile 모달 로딩 타이틀 i18n 하드코딩 제거 (P0-2)
+
+- 목표: 헤더 유저 메뉴 모달(Profile/MyPosts/Following/Bookmarks/Settings) 로딩 UI에서 ko/en/vi 하드코딩을 제거하고 messages 기반으로 단일화
+- 변경 내용
+  - `src/components/molecules/user/UserProfile.tsx`: dynamic 모달 로딩 fallback의 타이틀/aria-label을 `translations.*.loading` 기반으로 표시(하드코딩 제거)
+- 검증
+  - [x] `npm run lint`
+  - [x] `npm run type-check`
+  - [x] `SKIP_SITEMAP_DB=true npm run build`
+  - [x] `npm run test:e2e`

--- a/src/components/molecules/user/UserProfile.tsx
+++ b/src/components/molecules/user/UserProfile.tsx
@@ -11,18 +11,16 @@ import { useQueryClient } from '@tanstack/react-query';
 import Avatar from '@/components/atoms/Avatar';
 
 const ModalLoadingContext = createContext<(() => void) | null>(null);
-
-const LOADING_TITLE_BY_LOCALE = {
-  ko: '로딩 중...',
-  en: 'Loading...',
-  vi: 'Đang tải...',
-} as const;
+const ModalTranslationsContext = createContext<Record<string, unknown> | null>(null);
 
 function ModalLoadingFallback({ maxWidth }: { maxWidth: string }) {
-  const params = useParams();
-  const locale = params.lang as string || 'ko';
   const onClose = useContext(ModalLoadingContext);
-  const title = LOADING_TITLE_BY_LOCALE[locale as keyof typeof LOADING_TITLE_BY_LOCALE] || LOADING_TITLE_BY_LOCALE.ko;
+  const translations = useContext(ModalTranslationsContext) || {};
+  const title =
+    ((translations.profile as Record<string, string> | undefined)?.loading) ||
+    ((translations.post as Record<string, string> | undefined)?.loading) ||
+    ((translations.leaderboard as Record<string, string> | undefined)?.loading) ||
+    '';
 
   useEffect(() => {
     function handleEscape(event: KeyboardEvent) {
@@ -261,29 +259,39 @@ export default function UserProfile({ name, avatar, isLoggedIn, userId, onLogout
 
       {/* Modals */}
       {activeModal === 'profile' ? (
-        <ModalLoadingContext.Provider value={closeModal}>
-          <ProfileModal isOpen onClose={closeModal} translations={translations} />
-        </ModalLoadingContext.Provider>
+        <ModalTranslationsContext.Provider value={translations}>
+          <ModalLoadingContext.Provider value={closeModal}>
+            <ProfileModal isOpen onClose={closeModal} translations={translations} />
+          </ModalLoadingContext.Provider>
+        </ModalTranslationsContext.Provider>
       ) : null}
       {activeModal === 'myPosts' ? (
-        <ModalLoadingContext.Provider value={closeModal}>
-          <MyPostsModal isOpen onClose={closeModal} translations={translations} />
-        </ModalLoadingContext.Provider>
+        <ModalTranslationsContext.Provider value={translations}>
+          <ModalLoadingContext.Provider value={closeModal}>
+            <MyPostsModal isOpen onClose={closeModal} translations={translations} />
+          </ModalLoadingContext.Provider>
+        </ModalTranslationsContext.Provider>
       ) : null}
       {activeModal === 'following' ? (
-        <ModalLoadingContext.Provider value={closeModal}>
-          <FollowingModal isOpen onClose={closeModal} translations={translations} />
-        </ModalLoadingContext.Provider>
+        <ModalTranslationsContext.Provider value={translations}>
+          <ModalLoadingContext.Provider value={closeModal}>
+            <FollowingModal isOpen onClose={closeModal} translations={translations} />
+          </ModalLoadingContext.Provider>
+        </ModalTranslationsContext.Provider>
       ) : null}
       {activeModal === 'bookmarks' ? (
-        <ModalLoadingContext.Provider value={closeModal}>
-          <BookmarksModal isOpen onClose={closeModal} translations={translations} />
-        </ModalLoadingContext.Provider>
+        <ModalTranslationsContext.Provider value={translations}>
+          <ModalLoadingContext.Provider value={closeModal}>
+            <BookmarksModal isOpen onClose={closeModal} translations={translations} />
+          </ModalLoadingContext.Provider>
+        </ModalTranslationsContext.Provider>
       ) : null}
       {activeModal === 'settings' ? (
-        <ModalLoadingContext.Provider value={closeModal}>
-          <SettingsModal isOpen onClose={closeModal} translations={translations} />
-        </ModalLoadingContext.Provider>
+        <ModalTranslationsContext.Provider value={translations}>
+          <ModalLoadingContext.Provider value={closeModal}>
+            <SettingsModal isOpen onClose={closeModal} translations={translations} />
+          </ModalLoadingContext.Provider>
+        </ModalTranslationsContext.Provider>
       ) : null}
     </div>
   );


### PR DESCRIPTION
@codex

- Remove ko/en/vi hardcoded loading title in UserProfile modal loading fallback
- Use translations(profile/post/leaderboard.loading) via context for title/aria-label

Tests:
- npm run lint
- npm run type-check
- SKIP_SITEMAP_DB=true npm run build
- npm run test:e2e