### PR TITLE
[P0] i18n: add common.loading (P0-2)

### DIFF
--- a/docs/WORKING_PLAN.md
+++ b/docs/WORKING_PLAN.md
@@ -2862,3 +2862,10 @@ $gh-address-comments
   - [x] `npm run type-check`
   - [x] `SKIP_SITEMAP_DB=true npm run build`
   - [x] `npm run test:e2e`
+
+#### (2025-12-23) [P0] Subscriptions 로딩 문구 i18n 누락 제거 (P0-2)
+
+- 목표: 구독 페이지 로딩 상태에서 공통 `loading` 라벨이 없어 영어 fallback(`Loading...`)이 노출될 수 있는 케이스를 제거
+- 변경 내용
+  - `messages/ko.json`, `messages/vi.json`, `messages/en.json`: `common.loading` 추가
+  - `src/app/[lang]/(main)/subscriptions/SubscriptionsClient.tsx`: `copy.loading`을 `common.loading` 기반으로 단일화(영문 fallback 제거)

--- a/messages/en.json
+++ b/messages/en.json
@@ -34,7 +34,8 @@
     "share": "Share",
     "question": "Question",
     "verifiedUser": "Verified user",
-    "guidelineTooltip": "Be respectful, no hate; ads/contact links may be restricted; violations can be limited or penalized"
+    "guidelineTooltip": "Be respectful, no hate; ads/contact links may be restricted; violations can be limited or penalized",
+    "loading": "Loading..."
   },
   "postDetail": {
     "confirmDeletePost": "Are you sure you want to delete this post?",

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -51,7 +51,8 @@
     "share": "공유",
     "question": "질문",
     "verifiedUser": "인증된 사용자",
-    "guidelineTooltip": "예의·혐오 금지, 광고/연락처 제한, 위반 시 게시 제한/제재"
+    "guidelineTooltip": "예의·혐오 금지, 광고/연락처 제한, 위반 시 게시 제한/제재",
+    "loading": "로딩 중..."
   },
   "postDetail": {
     "confirmDeletePost": "정말 이 게시글을 삭제하시겠습니까?",

--- a/messages/vi.json
+++ b/messages/vi.json
@@ -51,7 +51,8 @@
     "share": "Chia sẻ",
     "question": "Câu hỏi",
     "verifiedUser": "Người dùng đã xác minh",
-    "guidelineTooltip": "Tôn trọng, không lăng mạ/hận thù; bài có quảng cáo/liên hệ/liên kết có thể bị hạn chế; vi phạm có thể bị giới hạn/xử lý"
+    "guidelineTooltip": "Tôn trọng, không lăng mạ/hận thù; bài có quảng cáo/liên hệ/liên kết có thể bị hạn chế; vi phạm có thể bị giới hạn/xử lý",
+    "loading": "Đang tải..."
   },
   "postDetail": {
     "confirmDeletePost": "Bạn có chắc chắn muốn xóa bài viết này?",

--- a/src/app/[lang]/(main)/subscriptions/SubscriptionsClient.tsx
+++ b/src/app/[lang]/(main)/subscriptions/SubscriptionsClient.tsx
@@ -58,7 +58,7 @@ export default function SubscriptionsClient({ translations, lang }: Subscription
       frequencyDaily: tSubscription.frequencyDaily || '',
       frequencyWeekly: tSubscription.frequencyWeekly || '',
       frequencyOff: tSubscription.frequencyOff || '',
-      loading: tCommon.loading || 'Loading...',
+      loading: tCommon.loading || '',
       updateError: tSubscription.updateError || '',
       unknownCategory: tCommon.uncategorized || '',
     };


### PR DESCRIPTION
@codex

- Add common.loading in messages and remove SubscriptionsClient English fallback

Files:
- messages/ko.json, messages/vi.json, messages/en.json
- src/app/[lang]/(main)/subscriptions/SubscriptionsClient.tsx
- docs/WORKING_PLAN.md

Tests:
- npm run lint
- npm run type-check
- SKIP_SITEMAP_DB=true npm run build
- npm run test:e2e