### PR TITLE
[P0] hide template excerpt and compact feed UI

### DIFF
--- a/docs/WORKING_PLAN.md
+++ b/docs/WORKING_PLAN.md
@@ -2897,3 +2897,17 @@ $gh-address-comments
   - [x] `npm run type-check`
   - [x] `SKIP_SITEMAP_DB=true npm run build`
   - [x] `npm run test:e2e`
+
+#### (2025-12-23) [P0] 피드 템플릿(모더레이션) 텍스트 숨김 + PostCard 숨김(×) 컴팩트 정렬 (P0-2/P0-3)
+
+- 목표: 글쓰기 템플릿(조건/목표/배경) 입력값이 피드 요약(excerpt)에 노출되어 “게시글 위주” 흐름이 깨지는 문제를 줄이고, 모바일에서 PostCard 숨김(×) 버튼이 상단에 떠 보이는 컴팩트함 저하를 개선
+- 변경 내용
+  - `src/app/[lang]/(main)/posts/new/NewPostClient.tsx`: 템플릿 `<p>`에 `data-vk-template="1"` / spacer에 `data-vk-template-spacer="1"`을 추가(피드 요약에서 안정적으로 제거 가능)
+  - `src/components/organisms/PostList.tsx`: 피드 excerpt 생성 시 템플릿 블록을 제거하고 본문만 요약(기존 템플릿 마크업도 제한적으로 호환)
+  - `src/components/molecules/cards/PostCard.tsx`: 숨김(×) 버튼을 카드 우상단 absolute에서 “작성자 헤더 행” 우측으로 이동(위 여백 감소, 위치 일관성 유지)
+  - `src/components/organisms/RecommendedUsersSection.tsx`: 모바일 추천 사용자 카드에서 아바타를 확대하고 팔로우 CTA 높이를 축소(세로/가로 비율 개선)
+- 검증
+  - [x] `npm run lint`
+  - [x] `npm run type-check`
+  - [x] `SKIP_SITEMAP_DB=true npm run build`
+  - [x] `npm run test:e2e`

--- a/src/app/[lang]/(main)/posts/new/NewPostClient.tsx
+++ b/src/app/[lang]/(main)/posts/new/NewPostClient.tsx
@@ -212,14 +212,14 @@ function NewPostForm({ translations, lang }: NewPostClientProps) {
   const templateHtml = useMemo(() => {
     if (templateSections.length === 0) return '';
     return templateSections
-      .map((section) => `<p><strong>${formatTemplateHtml(section)}</strong></p>`)
+      .map((section) => `<p data-vk-template="1"><strong>${formatTemplateHtml(section)}</strong></p>`)
       .join('');
   }, [templateSections]);
 
   const resolvedContent = useMemo(() => {
     const trimmedContent = content.trim();
     if (!templateHtml) return trimmedContent;
-    return trimmedContent ? `${templateHtml}<p></p>${trimmedContent}` : templateHtml;
+    return trimmedContent ? `${templateHtml}<p data-vk-template-spacer="1"></p>${trimmedContent}` : templateHtml;
   }, [content, templateHtml]);
 
   const contentImages = useMemo(() => extractImageSources(content), [content]);

--- a/src/components/molecules/cards/PostCard.tsx
+++ b/src/components/molecules/cards/PostCard.tsx
@@ -547,22 +547,10 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
         className={`question-card group relative ${isQuestion ? 'question-card--question' : ''} ${hasMedia ? 'question-card--with-media' : ''} ${isAdopted ? 'border-green-400 ring-1 ring-green-200 dark:ring-emerald-600/50' : ''
           }`}
       >
-			        <div className="question-card-main">
-				          <div className="question-card-body relative">
-        <div className="question-card-badges">
-          <Tooltip content={hideLabel} position="left" touchBehavior="longPress">
-            <button
-              type="button"
-              onClick={handleToggleHide}
-              aria-label={hideLabel}
-              className="flex h-6 w-6 items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
-            >
-              <span aria-hidden className="text-[14px] leading-none">×</span>
-            </button>
-          </Tooltip>
-        </div>
-				          <div className="flex items-start gap-2 mb-3 min-w-0">
-				            <div className="flex items-start gap-2 min-w-0 flex-1">
+        <div className="question-card-main">
+          <div className="question-card-body relative">
+            <div className="flex items-start gap-2 mb-3 min-w-0">
+              <div className="flex items-start gap-2 min-w-0 flex-1">
 		              <button
 	                type="button"
 	                className="shrink-0"
@@ -613,8 +601,18 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
 	                  <span>{formatDateTime(publishedAt, locale)}</span>
 	                </div>
 			              </div>
-			            </div>
-				          </div>
+              </div>
+              <Tooltip content={hideLabel} position="left" touchBehavior="longPress">
+                <button
+                  type="button"
+                  onClick={handleToggleHide}
+                  aria-label={hideLabel}
+                  className="shrink-0 flex h-6 w-6 items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+                >
+                  <span aria-hidden className="text-[14px] leading-none">×</span>
+                </button>
+              </Tooltip>
+            </div>
 			
 			          <div className="min-w-0">
 		            <div className="flex flex-wrap items-center gap-2 mb-2 min-w-0">

--- a/src/components/organisms/RecommendedUsersSection.tsx
+++ b/src/components/organisms/RecommendedUsersSection.tsx
@@ -85,9 +85,9 @@ export default function RecommendedUsersSection({
   const cardNameClass = compact ? 'text-[13px]' : 'text-sm';
   const cardMetaClass = compact ? 'text-[10px]' : 'text-[11px]';
   const badgeLabelClass = compact ? 'text-[10px] text-gray-500 dark:text-gray-400' : 'text-[11px] text-gray-500 dark:text-gray-400';
-  const avatarSize = compact ? 'xl' : 'lg';
+  const avatarSize = compact ? '2xl' : 'lg';
   const followButtonSize = 'xs';
-  const followButtonClassName = compact ? 'min-h-[36px] px-3 py-1 text-xs' : 'min-h-[36px] px-3 py-1 text-xs';
+  const followButtonClassName = compact ? 'min-h-[32px] px-3 py-1 text-xs' : 'min-h-[36px] px-3 py-1 text-xs';
 
   const mergedMetaLabels = useMemo<Record<string, string>>(() => ({
     followers: followerLabel,


### PR DESCRIPTION
### Summary
- Hide NewPost template(moderation) block from feed excerpts while keeping detail content intact
- Make PostCard hide(×) control more compact by aligning with author row
- Tighten RecommendedUsers CTA sizing on mobile

### Validation
- npm run lint
- npm run type-check
- SKIP_SITEMAP_DB=true npm run build
- npm run test:e2e

cc @codex
