### PR TITLE
[P0] Remove home feed toggle overlay

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -357,10 +357,6 @@
   display: none;
 }
 
-.vk-home-feed-toggle {
-  bottom: calc(56px + env(safe-area-inset-bottom, 0px) + 10px);
-}
-
 @theme inline {
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/src/components/organisms/BottomNavigation.tsx
+++ b/src/components/organisms/BottomNavigation.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'nextjs-toploader/app';
-import { useParams, usePathname, useSearchParams } from 'next/navigation';
+import { useParams, usePathname } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { Home, Search, PenSquare, ShieldCheck, User } from 'lucide-react';
 import { dispatchHomeReset } from '@/utils/homeReset';
@@ -15,60 +15,13 @@ interface BottomNavigationProps {
 export default function BottomNavigation({ translations }: BottomNavigationProps) {
   const router = useRouter();
   const pathname = usePathname();
-  const searchParams = useSearchParams();
   const params = useParams();
   const { data: session } = useSession();
   const user = session?.user;
   const { openLoginPrompt } = useLoginPrompt();
   const lang = (params?.lang as string) || 'ko';
-
-  const isHomePath = pathname === `/${lang}`;
-
-  const homeFeed = useMemo(() => {
-    const c = searchParams?.get('c');
-    if (!c) return 'popular';
-    if (c === 'popular' || c === 'latest') return c;
-    return null;
-  }, [searchParams]);
-
-  const popularLabel = useMemo(() => {
-    const labels = (translations?.sidebar || {}) as Record<string, string>;
-    return labels.popular || '';
-  }, [translations]);
-
-  const latestLabel = useMemo(() => {
-    const labels = (translations?.sidebar || {}) as Record<string, string>;
-    return labels.latest || '';
-  }, [translations]);
-
-  const handleHomeFeedToggle = (next: 'popular' | 'latest') => {
-    dispatchHomeReset();
-    const nextParams = new URLSearchParams(searchParams?.toString());
-    nextParams.set('c', next);
-    nextParams.delete('page');
-    const qs = nextParams.toString();
-    router.push(qs ? `/${lang}?${qs}` : `/${lang}`);
-  };
-
-  const showHomeFeedToggle = isHomePath && homeFeed !== null;
-  const [isFeedToggleReady, setIsFeedToggleReady] = useState(false);
   const [isKeyboardOpen, setIsKeyboardOpen] = useState(false);
   const maxViewportHeightRef = useRef(0);
-
-  useEffect(() => {
-    if (!showHomeFeedToggle) {
-      setIsFeedToggleReady(false);
-      return;
-    }
-
-    const raf = window.requestAnimationFrame(() => {
-      setIsFeedToggleReady(true);
-    });
-
-    return () => {
-      window.cancelAnimationFrame(raf);
-    };
-  }, [showHomeFeedToggle]);
 
   useEffect(() => {
     const viewport = window.visualViewport;
@@ -93,12 +46,11 @@ export default function BottomNavigation({ translations }: BottomNavigationProps
   useEffect(() => {
     const root = document.documentElement;
     const baseOffset = 72;
-    const feedToggleOffset = 128;
-    root.style.setProperty('--vk-bottom-safe-offset', `${showHomeFeedToggle ? feedToggleOffset : baseOffset}px`);
+    root.style.setProperty('--vk-bottom-safe-offset', `${baseOffset}px`);
     return () => {
       root.style.setProperty('--vk-bottom-safe-offset', `${baseOffset}px`);
     };
-  }, [showHomeFeedToggle]);
+  }, []);
 
   const navItems = useMemo(() => {
     const labels = (translations?.bottomNav || {}) as Record<string, string>;
@@ -161,7 +113,7 @@ export default function BottomNavigation({ translations }: BottomNavigationProps
     }
     if (href === `/${lang}`) {
       dispatchHomeReset();
-      router.push(`/${lang}?c=${homeFeed || 'popular'}`);
+      router.push(`/${lang}`);
       return;
     }
     router.push(href);
@@ -169,44 +121,6 @@ export default function BottomNavigation({ translations }: BottomNavigationProps
 
   return (
     <>
-      {showHomeFeedToggle && !isKeyboardOpen ? (
-        <div
-          className={`vk-home-feed-toggle md:hidden pointer-events-none fixed inset-x-0 bottom-[calc(env(safe-area-inset-bottom,0px)+72px+12px)] z-40 flex justify-center transition-all duration-200 ease-out ${
-            isFeedToggleReady ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-2'
-          }`}
-        >
-          <div className="pointer-events-auto inline-flex items-center gap-1.5 rounded-full border border-gray-200/70 dark:border-gray-700/60 bg-white/35 dark:bg-gray-900/30 backdrop-blur px-1.5 py-1.5 shadow-lg">
-            <button
-              type="button"
-              onClick={() => handleHomeFeedToggle('popular')}
-              className={`inline-flex items-center gap-1.5 rounded-full px-4 py-2.5 text-sm font-semibold transition duration-200 ease-out active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 ${
-                homeFeed === 'popular'
-                  ? 'bg-blue-600/35 text-white shadow-sm'
-                  : 'text-gray-700 dark:text-gray-200 hover:bg-white/20 dark:hover:bg-gray-800/30'
-              }`}
-              aria-label={popularLabel}
-              aria-pressed={homeFeed === 'popular'}
-            >
-              <span aria-hidden>🔥</span>
-              <span>{popularLabel}</span>
-            </button>
-            <button
-              type="button"
-              onClick={() => handleHomeFeedToggle('latest')}
-              className={`inline-flex items-center gap-1.5 rounded-full px-4 py-2.5 text-sm font-semibold transition duration-200 ease-out active:scale-[0.98] focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 ${
-                homeFeed === 'latest'
-                  ? 'bg-blue-600/35 text-white shadow-sm'
-                  : 'text-gray-700 dark:text-gray-200 hover:bg-white/20 dark:hover:bg-gray-800/30'
-              }`}
-              aria-label={latestLabel}
-              aria-pressed={homeFeed === 'latest'}
-            >
-              <span aria-hidden>🕒</span>
-              <span>{latestLabel}</span>
-            </button>
-          </div>
-        </div>
-      ) : null}
       <nav className={`md:hidden fixed inset-x-0 bottom-0 z-50 border-t border-gray-200/80 dark:border-gray-800/80 bg-white/95 dark:bg-gray-900/95 backdrop-blur-lg shadow-lg ${isKeyboardOpen ? 'hidden' : ''}`}>
         <div className="pb-[env(safe-area-inset-bottom,0px)]">
           <div className="grid grid-cols-5 h-14 px-2">


### PR DESCRIPTION
@codex

- Removes the floating Home feed toggle overlay (🔥 인기 / 🕒 최신) that was obscuring content / flickering on mobile.
- Keeps bottom safe-area padding via `--vk-bottom-safe-offset` (fixed 72px).

Validation:
- npm run lint
- npm run type-check
- SKIP_SITEMAP_DB=true npm run build
- npm run test:e2e