### PR TITLE
[P0] Tweak recommended users & PostCard mobile UI

### DIFF
--- a/src/components/molecules/cards/PostCard.tsx
+++ b/src/components/molecules/cards/PostCard.tsx
@@ -549,7 +549,7 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
       >
         <div className="question-card-main">
           <div className="question-card-body relative">
-            <div className="flex items-start gap-2 mb-3 min-w-0">
+            <div className="flex items-start gap-2 mb-2 min-w-0">
               <div className="flex items-start gap-2 min-w-0 flex-1">
 		              <button
 	                type="button"
@@ -607,7 +607,7 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
                   type="button"
                   onClick={handleToggleHide}
                   aria-label={hideLabel}
-                  className="shrink-0 flex h-6 w-6 items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+                  className="shrink-0 mt-1 flex h-6 w-6 items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
                 >
                   <span aria-hidden className="text-[14px] leading-none">×</span>
                 </button>
@@ -702,7 +702,7 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
 	                  onClick={handleAnswerCountClick}
 	                  aria-label={certifiedTooltipContent || certifiedDisplayLabel}
 	                  title={certifiedTooltipContent || certifiedDisplayLabel}
-	                  className="group inline-flex items-center gap-1 text-[11px] font-semibold text-emerald-700 dark:text-emerald-200 hover:text-emerald-800 dark:hover:text-emerald-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 min-w-0 max-w-[140px] sm:max-w-none"
+	                  className="group inline-flex items-center gap-1 text-[11px] font-semibold text-emerald-700 dark:text-emerald-200 hover:text-emerald-800 dark:hover:text-emerald-100 focus:outline-none focus-visible:ring-2 focus-visible:ring-emerald-500 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 min-w-0 max-w-[120px] sm:max-w-none"
 	                >
 	                  <ShieldCheck className="h-3 w-3 shrink-0" />
 	                  <span className="truncate">{certifiedDisplayLabel}</span>

--- a/src/components/organisms/PostList.tsx
+++ b/src/components/organisms/PostList.tsx
@@ -220,6 +220,9 @@ export default function PostList({ selectedCategory = 'all', isSearchMode = fals
     data?.pages.flatMap((page: PaginatedResponse<PostListItem>) => page.data) || [];
 
   const shouldInsertRecommended = Boolean(session?.user) && !isSearchMode && (selectedCategory === 'popular' || selectedCategory === 'latest') && allPosts.length >= 5;
+  const shouldInsertFollowingRecommended = selectedCategory === 'following'
+    && !isSearchMode
+    && allPosts.length > 0;
   const shouldFetchRecommended = Boolean(session?.user) && (selectedCategory === 'following' || shouldInsertRecommended);
   const {
     data: recommended,
@@ -385,7 +388,7 @@ export default function PostList({ selectedCategory = 'all', isSearchMode = fals
           </div>
         )}
 
-      {selectedCategory === 'following' && !isLoading && allPosts.length === 0 && (recommendedLoading || sortedRecommendations.length) ? (
+  {selectedCategory === 'following' && !isLoading && allPosts.length === 0 && (recommendedLoading || sortedRecommendations.length) ? (
         <div className="mb-4">
           <RecommendedUsersSection
             title={recommendedUsersLabel}
@@ -472,6 +475,36 @@ export default function PostList({ selectedCategory = 'all', isSearchMode = fals
                     translations={translations}
                   />
                 </div>
+                {shouldInsertFollowingRecommended && idx === 0 && (recommendedLoading || sortedRecommendations.length > 0) ? (
+                  <div className="mt-1">
+                    <RecommendedUsersSection
+                      title={recommendedUsersLabel}
+                      locale={locale}
+                      users={sortedRecommendations}
+                      isLoading={recommendedLoading}
+                      translations={translations}
+                      hasNextPage={hasNextRecommendedPage}
+                      isFetchingNextPage={isFetchingNextRecommendedPage}
+                      onLoadMore={() => {
+                        if (hasNextRecommendedPage && !isFetchingNextRecommendedPage) {
+                          fetchNextRecommendedPage();
+                        }
+                      }}
+                      followerLabel={followerLabel}
+                      postsLabel={postsLabel}
+                      followingLabel={followingLabel}
+                      metaLabels={metaLabels}
+                      verifiedLabel={verifiedLabel}
+                      trustBadgeTranslations={tTrust}
+                      badgeLabels={badgeLabels}
+                      previousLabel={previousLabel}
+                      nextLabel={nextLabel}
+                      anonymousLabel={anonymousLabel}
+                      onboardingLabels={tOnboarding}
+                      compact
+                    />
+                  </div>
+                ) : null}
                 {shouldInsertRecommended && idx === 4 && (recommendedLoading || sortedRecommendations.length > 0) ? (
                   <div className="mt-1">
                     <RecommendedUsersSection

--- a/src/components/organisms/RecommendedUsersSection.tsx
+++ b/src/components/organisms/RecommendedUsersSection.tsx
@@ -87,7 +87,7 @@ export default function RecommendedUsersSection({
   const badgeLabelClass = compact ? 'text-[10px] text-gray-500 dark:text-gray-400' : 'text-[11px] text-gray-500 dark:text-gray-400';
   const avatarSize = compact ? '2xl' : 'lg';
   const followButtonSize = 'xs';
-  const followButtonClassName = compact ? 'min-h-[32px] px-3 py-1 text-xs' : 'min-h-[36px] px-3 py-1 text-xs';
+  const followButtonClassName = compact ? 'min-h-[28px] px-2.5 py-0.5 text-[11px] whitespace-nowrap' : 'min-h-[36px] px-3 py-1 text-xs';
 
   const mergedMetaLabels = useMemo<Record<string, string>>(() => ({
     followers: followerLabel,


### PR DESCRIPTION
@codex

- Following 탭에서도 추천 사용자 섹션을 1개 게시글 뒤에 노출(기존: 게시글 0개일 때만).
- 추천 사용자 카드에서 팔로우 버튼 크기/패딩 축소(모바일 과도한 강조 완화).
- PostCard 헤더 여백/숨김 X 정렬/인증 답변 라벨 폭을 소폭 조정해 모바일 밀림/클립 완화.

Tests:
- npm run lint
- npm run type-check
- SKIP_SITEMAP_DB=true npm run build
- npm run test:e2e