### PR TITLE
fix: mobile feed chips & sidebar wrapping

### DIFF
--- a/src/app/api/users/recommended/route.ts
+++ b/src/app/api/users/recommended/route.ts
@@ -30,13 +30,13 @@ export async function GET(req: NextRequest) {
       },
     });
 
-    const viewerUserType = viewer?.userType || null;
-    const viewerVisaType = viewer?.visaType || null;
-    const viewerKoreanLevel = viewer?.koreanLevel || null;
-    const viewerInterests = (viewer?.interests || []).filter((value) => typeof value === 'string' && value.trim().length > 0);
-    const viewerUserTypeSql = viewerUserType ? sql`${viewerUserType}::text` : null;
-    const viewerVisaTypeSql = viewerVisaType ? sql`${viewerVisaType}::text` : null;
-    const viewerKoreanLevelSql = viewerKoreanLevel ? sql`${viewerKoreanLevel}::text` : null;
+    const viewerUserType = typeof viewer?.userType === 'string' && viewer.userType.trim() ? viewer.userType.trim() : null;
+    const viewerVisaType = typeof viewer?.visaType === 'string' && viewer.visaType.trim() ? viewer.visaType.trim() : null;
+    const viewerKoreanLevel =
+      typeof viewer?.koreanLevel === 'string' && viewer.koreanLevel.trim() ? viewer.koreanLevel.trim() : null;
+    const viewerInterests = (viewer?.interests || []).filter(
+      (value) => typeof value === 'string' && value.trim().length > 0
+    );
     const viewerInterestsArray = viewerInterests.length > 0
       ? sql`ARRAY[${sql.join(viewerInterests.map((value) => sql`${value}::text`), sql`, `)}]::text[]`
       : sql`ARRAY[]::text[]`;
@@ -65,9 +65,9 @@ export async function GET(req: NextRequest) {
     const total = Number(totalResult[0]?.count || 0);
 
     const matchScoreParts = [
-      viewerUserTypeSql ? sql`(CASE WHEN ${users.userType} = ${viewerUserTypeSql} THEN 4 ELSE 0 END)` : sql`0`,
-      viewerVisaTypeSql ? sql`(CASE WHEN ${users.visaType} = ${viewerVisaTypeSql} THEN 3 ELSE 0 END)` : sql`0`,
-      viewerKoreanLevelSql ? sql`(CASE WHEN ${users.koreanLevel} = ${viewerKoreanLevelSql} THEN 1 ELSE 0 END)` : sql`0`,
+      viewerUserType ? sql`(CASE WHEN ${users.userType} = ${viewerUserType} THEN 4 ELSE 0 END)` : sql`0`,
+      viewerVisaType ? sql`(CASE WHEN ${users.visaType} = ${viewerVisaType} THEN 3 ELSE 0 END)` : sql`0`,
+      viewerKoreanLevel ? sql`(CASE WHEN ${users.koreanLevel} = ${viewerKoreanLevel} THEN 1 ELSE 0 END)` : sql`0`,
       viewerInterests.length > 0
         ? sql`(CASE WHEN COALESCE(${users.interests} && ${viewerInterestsArray}, false) THEN 3 ELSE 0 END)`
         : sql`0`,
@@ -150,7 +150,7 @@ export async function GET(req: NextRequest) {
       return interestList[0] || '';
     };
 
-      const formattedUsers = recommendedUsers.map((user) => {
+    const formattedUsers = recommendedUsers.map((user) => {
       const resolvedInterests = (user.interests || [])
         .map((value) => (typeof value === 'string' ? resolveInterest(value) : ''))
         .filter((value) => value.length > 0);

--- a/src/components/molecules/cards/PostCard.tsx
+++ b/src/components/molecules/cards/PostCard.tsx
@@ -261,25 +261,34 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
       ? (tCommon.question || questionPostLabel || '')
       : (tCommon.share || '');
 
-    const candidates = [
-      ...(displayTags.length > 0 ? displayTags : []),
-      categoryLabel,
-      subcategoryLabel,
-      purposeLabel,
-    ]
+    const moderationCandidates = (displayTags.length > 0 ? displayTags : [])
+      .map((v) => v?.trim())
+      .filter(Boolean) as string[];
+    const contextCandidates = [categoryLabel, subcategoryLabel, purposeLabel]
       .map((v) => v?.trim())
       .filter(Boolean) as string[];
 
-    return candidates
-      .filter((v) => {
-        const key = normalizeKey(v);
-        if (!key) return false;
-        if (reserved.has(key)) return false;
-        if (seen.has(key)) return false;
-        seen.add(key);
-        return true;
-      })
-      .slice(0, 3);
+    const isSelectable = (value: string) => {
+      const key = normalizeKey(value);
+      if (!key) return false;
+      if (reserved.has(key)) return false;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    };
+
+    const selected: string[] = [];
+    for (const candidate of moderationCandidates) {
+      if (selected.length >= 2) break;
+      if (!isSelectable(candidate)) continue;
+      selected.push(candidate);
+    }
+    for (const candidate of contextCandidates) {
+      if (selected.length >= 3) break;
+      if (!isSelectable(candidate)) continue;
+      selected.push(candidate);
+    }
+    return selected;
   }, [
     categoryLabel,
     displayTags,
@@ -607,9 +616,9 @@ export default function PostCard({ id, author, title, excerpt, tags, stats, cate
                   type="button"
                   onClick={handleToggleHide}
                   aria-label={hideLabel}
-                  className="shrink-0 mt-1 flex h-6 w-6 items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+                  className="shrink-0 self-start mt-0.5 flex h-5 w-5 items-center justify-center text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
                 >
-                  <span aria-hidden className="text-[14px] leading-none">×</span>
+                  <span aria-hidden className="text-[13px] leading-none">×</span>
                 </button>
               </Tooltip>
             </div>

--- a/src/components/organisms/BottomNavigation.tsx
+++ b/src/components/organisms/BottomNavigation.tsx
@@ -121,7 +121,11 @@ export default function BottomNavigation({ translations }: BottomNavigationProps
 
   return (
     <>
-      <nav className={`md:hidden fixed inset-x-0 bottom-0 z-50 border-t border-gray-200/80 dark:border-gray-800/80 bg-white/95 dark:bg-gray-900/95 backdrop-blur-lg shadow-lg ${isKeyboardOpen ? 'hidden' : ''}`}>
+      <nav
+        className={`md:hidden fixed inset-x-0 bottom-0 z-50 border-t border-gray-200/80 dark:border-gray-800/80 bg-white dark:bg-gray-900 backdrop-blur-lg shadow-lg ${
+          isKeyboardOpen ? 'hidden' : ''
+        }`}
+      >
         <div className="pb-[env(safe-area-inset-bottom,0px)]">
           <div className="grid grid-cols-5 h-14 px-2">
             {navItems.map((item) => {

--- a/src/components/organisms/CategorySidebar.tsx
+++ b/src/components/organisms/CategorySidebar.tsx
@@ -380,7 +380,10 @@ export default function CategorySidebar({
                       const apiChild = apiBySlug.get(child.slug);
                       const subscribed = apiChild ? subscribedIds.has(apiChild.id) : false;
                       return (
-                        <div key={child.slug} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 pr-4 py-1 min-w-0">
+                        <div
+                          key={child.slug}
+                          className="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] items-start sm:items-center gap-2 pr-4 py-1 min-w-0"
+                        >
                           <CategoryItem
                             id={child.slug}
                             name={getCategoryName(child, locale)}
@@ -391,20 +394,16 @@ export default function CategorySidebar({
                             className="!px-2 !py-2 flex-1 text-sm"
                           />
                           {apiChild ? (
-                          <button
-                            onClick={() => handleSubscribe(apiChild.id)}
-                            className={`shrink-0 text-center whitespace-normal break-words text-[11px] min-h-[32px] px-2.5 sm:px-3 py-1.5 rounded-full transition-colors max-w-[140px] ${
-                              subscribed
-                                ? 'border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 bg-transparent hover:bg-gray-50 dark:hover:bg-gray-800'
-                                : 'border border-transparent bg-blue-600 text-white shadow-sm hover:bg-blue-700'
-                            }`}
-                          >
-                            <span className="block leading-snug">
-                              {subscribed
-                                ? subscribedLabel
-                                : subscribeLabel}
-                            </span>
-                          </button>
+                            <button
+                              onClick={() => handleSubscribe(apiChild.id)}
+                              className={`shrink-0 justify-self-end text-center whitespace-normal break-words text-[11px] min-h-[32px] px-2.5 sm:px-3 py-1.5 rounded-full transition-colors max-w-[140px] ${
+                                subscribed
+                                  ? 'border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 bg-transparent hover:bg-gray-50 dark:hover:bg-gray-800'
+                                  : 'border border-transparent bg-blue-600 text-white shadow-sm hover:bg-blue-700'
+                              }`}
+                            >
+                              <span className="block leading-snug">{subscribed ? subscribedLabel : subscribeLabel}</span>
+                            </button>
                           ) : null}
                         </div>
                       );
@@ -423,7 +422,10 @@ export default function CategorySidebar({
           {topicSubscriptions.length > 0 ? (
             <div className="space-y-1">
               {topicSubscriptions.map((cat) => (
-                <div key={cat.id} className="grid grid-cols-[minmax(0,1fr)_auto] items-center gap-2 pr-3 pl-0 py-1.5 min-w-0">
+                <div
+                  key={cat.id}
+                  className="grid grid-cols-1 sm:grid-cols-[minmax(0,1fr)_auto] items-start sm:items-center gap-2 pr-3 pl-0 py-1.5 min-w-0"
+                >
                   <CategoryItem
                     id={cat.slug}
                     name={getTranslatedCategoryName(cat)}
@@ -435,7 +437,7 @@ export default function CategorySidebar({
                   />
                   <button
                     onClick={() => handleSubscribe(cat.id)}
-                    className="shrink-0 text-center whitespace-normal break-words text-[11px] min-h-[32px] px-2.5 sm:px-3 py-1.5 rounded-full border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 bg-transparent hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors max-w-[140px]"
+                    className="shrink-0 justify-self-end text-center whitespace-normal break-words text-[11px] min-h-[32px] px-2.5 sm:px-3 py-1.5 rounded-full border border-gray-200 dark:border-gray-700 text-gray-600 dark:text-gray-300 bg-transparent hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors max-w-[140px]"
                   >
                     <span className="block leading-snug">
                       {subscribedLabel}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -36,7 +36,7 @@ function SheetOverlay({
     <SheetPrimitive.Overlay
       data-slot="sheet-overlay"
       className={cn(
-        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/60",
         className
       )}
       {...props}


### PR DESCRIPTION
@codex

## Summary
- Stabilize `/api/users/recommended` match scoring parameters to avoid SQL type inference edge-cases.
- Feed `PostCard` hashtag policy: max 3 chips (2 from moderation/tags + 1 from category/subcategory/purpose), filter low-signal tags.
- Mobile polish: smaller hide (×) button, bottom nav background opaque to prevent content bleed-through.
- Sidebar subscribe buttons: stack on small screens to prevent right-edge clipping; Sheet overlay slightly darker.

## Tests
- npm run lint
- npm run type-check
- SKIP_SITEMAP_DB=true npm run build
- npm run test:e2e