### PR TITLE
[FE] refine mobile recommended users + bottom nav

### DIFF
--- a/docs/WORKING_PLAN.md
+++ b/docs/WORKING_PLAN.md
@@ -3012,3 +3012,17 @@ $gh-address-comments
   - [x] `npm run type-check`
   - [x] `SKIP_SITEMAP_DB=true npm run build`
   - [x] `npm run test:e2e`
+
+#### (2025-12-24) [FE] 추천 사용자 카드 비율 개선 + 하단탭 시각 분리(불투명) (P0-2/P0-3)
+
+- 목표: 추천 사용자 카드에서 “아바타/팔로우 버튼 비율”과 “가로 카드 폭”을 모바일에 맞게 안정화하고, 하단 고정 탭이 콘텐츠 위에 겹쳐 보이는 인상을 줄인다.
+- 변경 내용
+  - `src/components/organisms/RecommendedUsersSection.tsx`
+    - compact 모드 카드 폭 확대(auto-cols)로 텍스트 잘림/겹침 완화
+    - 아바타 크기 상향(`2xl`) + 팔로우 버튼 높이/패딩 축소(`min-h` 24px)
+  - `src/components/organisms/BottomNavigation.tsx`: 배경을 불투명(`bg-white`/`dark:bg-gray-900`)으로 고정해 콘텐츠가 비쳐 보이는 겹침 인상을 완화
+- 검증
+  - [x] `npm run lint`
+  - [x] `npm run type-check`
+  - [x] `SKIP_SITEMAP_DB=true npm run build`
+  - [x] `npm run test:e2e`

--- a/src/components/organisms/BottomNavigation.tsx
+++ b/src/components/organisms/BottomNavigation.tsx
@@ -122,7 +122,7 @@ export default function BottomNavigation({ translations }: BottomNavigationProps
   return (
     <>
       <nav
-        className={`md:hidden fixed inset-x-0 bottom-0 z-50 border-t border-gray-200/80 dark:border-gray-800/80 bg-white/95 dark:bg-gray-900/95 backdrop-blur-lg shadow-lg ${
+        className={`md:hidden fixed inset-x-0 bottom-0 z-50 border-t border-gray-200/80 dark:border-gray-800/80 bg-white dark:bg-gray-900 shadow-lg ${
           isKeyboardOpen ? 'hidden' : ''
         }`}
       >

--- a/src/components/organisms/RecommendedUsersSection.tsx
+++ b/src/components/organisms/RecommendedUsersSection.tsx
@@ -85,10 +85,10 @@ export default function RecommendedUsersSection({
   const cardNameClass = compact ? 'text-[13px]' : 'text-sm';
   const cardMetaClass = compact ? 'text-[10px]' : 'text-[11px]';
   const badgeLabelClass = compact ? 'text-[10px] text-gray-500 dark:text-gray-400' : 'text-[11px] text-gray-500 dark:text-gray-400';
-  const avatarSize = compact ? 'xl' : 'xl';
+  const avatarSize = compact ? '2xl' : 'xl';
   const followButtonSize = 'xs';
   const followButtonClassName = compact
-    ? 'min-h-[28px] px-2.5 py-0.5 text-[11px] whitespace-nowrap'
+    ? '!min-h-[24px] !px-2 !py-0.5 text-[11px] whitespace-nowrap'
     : 'min-h-[28px] px-2.5 py-0.5 text-[11px] whitespace-nowrap sm:min-h-[36px] sm:px-3 sm:py-1 sm:text-xs';
 
   const mergedMetaLabels = useMemo<Record<string, string>>(() => ({
@@ -320,7 +320,7 @@ export default function RecommendedUsersSection({
         onScroll={markInteracted}
         className={`grid grid-flow-col ${
           compact
-            ? 'auto-cols-[minmax(320px,calc(100vw-4.5rem))] sm:auto-cols-[minmax(380px,1fr)]'
+            ? 'auto-cols-[minmax(320px,calc(100vw-2.75rem))] sm:auto-cols-[minmax(420px,1fr)]'
             : 'auto-cols-[minmax(260px,1fr)] sm:auto-cols-[minmax(320px,1fr)]'
         } lg:auto-cols-[minmax(280px,1fr)] ${compact ? 'gap-2' : 'gap-3'} overflow-x-auto scrollbar-hide snap-x snap-mandatory pb-1 pr-3 scroll-px-3`}
       >


### PR DESCRIPTION
@codex

- Mobile: recommended users carousel cards widen + avatar/follow ratio tightened
- Mobile: bottom nav background made opaque to reduce ‘content overlap’ impression

Validation: npm run lint, npm run type-check, SKIP_SITEMAP_DB=true npm run build, npm run test:e2e