### PR TITLE
[P1-2] Endpoint rate limit for toggle actions

### DIFF
--- a/docs/WORKING_PLAN.md
+++ b/docs/WORKING_PLAN.md
@@ -1638,7 +1638,7 @@ $gh-address-comments
 #### (2025-12-20) [BE] P1-2 Rate limit 고도화 (P1)
 
 - 플랜(체크리스트)
-  - [ ] [BE] 엔드포인트별 정책 세분화
+  - [x] [BE] 엔드포인트별 정책 세분화
   - [ ] [BE] CAPTCHA 옵션 설계
 
 - 정책 세분화(엔드포인트별/유저별), 오탐 대응, CAPTCHA 옵션 검토
@@ -3438,6 +3438,23 @@ $gh-address-comments
   - `e2e/functional.spec.ts`: “notifications 페이지 로드” 기능 테스트 추가
 - PR
   - https://github.com/LEE-SANG-BOK/VKC-2-/pull/120
+- 검증
+  - [x] `npm run lint`
+  - [x] `npm run type-check`
+  - [x] `SKIP_SITEMAP_DB=true npm run build`
+  - [x] `npm run test:e2e`
+
+#### (2025-12-28) [P1-2] Rate limit 정책 세분화: 토글 엔드포인트 + Retry-After 정확화 (P1-2)
+
+- 목표: 토글(팔로우/좋아요/북마크) 계열까지 “엔드포인트별/유저별” rate limit을 적용하고, DB 기반 limiter는 Retry-After를 더 정확히 계산한다.
+- 변경
+  - `src/lib/api/rateLimit.ts`: DB 기반 `checkRateLimit`을 “최근 max개” 조회로 변경해 Retry-After를 정확화 + `checkInMemoryRateLimit` 추가
+  - `src/app/api/users/[id]/follow/route.ts`: 팔로우(add) 요청에 per-user limiter 적용(언팔로우는 제외)
+  - `src/app/api/posts/[id]/like/route.ts`: 좋아요(add) 요청에 per-user limiter 적용(취소는 제외)
+  - `src/app/api/posts/[id]/bookmark/route.ts`: 북마크(add) 요청에 per-user limiter 적용(취소는 제외)
+  - `src/app/api/answers/[id]/like/route.ts`: 도움됨(add) 요청에 per-user limiter 적용(취소는 제외)
+  - `src/app/api/comments/[id]/like/route.ts`: 댓글 좋아요(add) 요청에 per-user limiter 적용(취소는 제외)
+  - `e2e/functional.spec.ts`: 반복 좋아요 요청에서 429(Retry-After 포함) 검증 추가
 - 검증
   - [x] `npm run lint`
   - [x] `npm run type-check`

--- a/src/app/api/posts/[id]/bookmark/route.ts
+++ b/src/app/api/posts/[id]/bookmark/route.ts
@@ -1,16 +1,22 @@
 import { NextRequest } from 'next/server';
 import { db } from '@/lib/db';
 import { posts, bookmarks } from '@/lib/db/schema';
-import { successResponse, notFoundResponse, unauthorizedResponse, serverErrorResponse } from '@/lib/api/response';
+import { successResponse, notFoundResponse, unauthorizedResponse, serverErrorResponse, rateLimitResponse } from '@/lib/api/response';
 import { getSession } from '@/lib/api/auth';
 import { eq, and } from 'drizzle-orm';
 import { isE2ETestMode } from '@/lib/e2e/mode';
 import { getE2ERequestState } from '@/lib/e2e/request';
 import { togglePostBookmark as toggleE2EPostBookmark } from '@/lib/e2e/actions';
+import { checkInMemoryRateLimit } from '@/lib/api/rateLimit';
 
 interface RouteContext {
   params: Promise<{ id: string }>;
 }
+
+const bookmarkRateLimitWindowMs = 60_000;
+const bookmarkRateLimitMax = 40;
+const bookmarkRateLimitE2EWindowMs = 10_000;
+const bookmarkRateLimitE2EMax = 5;
 
 /**
  * POST /api/posts/[id]/bookmark
@@ -20,8 +26,23 @@ export async function POST(request: NextRequest, context: RouteContext) {
   try {
     if (isE2ETestMode()) {
       const { id: postId } = await context.params;
-      const { store, userId } = getE2ERequestState(request);
+      const { store, namespace, userId } = getE2ERequestState(request);
       if (!userId) return unauthorizedResponse();
+      const alreadyBookmarked = store.bookmarksByUserId.get(userId)?.has(postId) === true;
+      if (!alreadyBookmarked) {
+        const rateLimit = checkInMemoryRateLimit({
+          key: `${namespace}:${userId}:post-bookmark`,
+          windowMs: bookmarkRateLimitE2EWindowMs,
+          max: bookmarkRateLimitE2EMax,
+        });
+        if (!rateLimit.allowed) {
+          return rateLimitResponse(
+            '북마크 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.',
+            'BOOKMARK_RATE_LIMITED',
+            rateLimit.retryAfterSeconds
+          );
+        }
+      }
       const result = toggleE2EPostBookmark(store, userId, postId);
       if (!result) {
         return notFoundResponse('게시글을 찾을 수 없습니다.');
@@ -60,6 +81,19 @@ export async function POST(request: NextRequest, context: RouteContext) {
 
       return successResponse({ isBookmarked: false }, '북마크를 취소했습니다.');
     } else {
+      const rateLimit = checkInMemoryRateLimit({
+        key: `${user.id}:post-bookmark`,
+        windowMs: bookmarkRateLimitWindowMs,
+        max: bookmarkRateLimitMax,
+      });
+      if (!rateLimit.allowed) {
+        return rateLimitResponse(
+          '북마크 요청이 너무 많습니다. 잠시 후 다시 시도해주세요.',
+          'BOOKMARK_RATE_LIMITED',
+          rateLimit.retryAfterSeconds
+        );
+      }
+
       // 북마크 추가
       await db.insert(bookmarks).values({
         userId: user.id,

--- a/src/lib/api/rateLimit.ts
+++ b/src/lib/api/rateLimit.ts
@@ -1,5 +1,5 @@
 import { db } from '@/lib/db';
-import { and, eq, gte, sql } from 'drizzle-orm';
+import { and, desc, eq, gte } from 'drizzle-orm';
 
 type RateLimitCheck = {
   table: any;
@@ -10,6 +10,14 @@ type RateLimitCheck = {
   max: number;
 };
 
+type InMemoryRateLimitCheck = {
+  key: string;
+  windowMs: number;
+  max: number;
+};
+
+const memoryRateStore = new Map<string, { count: number; resetAt: number }>();
+
 export async function checkRateLimit({
   table,
   userColumn,
@@ -18,14 +26,55 @@ export async function checkRateLimit({
   windowMs,
   max,
 }: RateLimitCheck) {
-  const since = new Date(Date.now() - windowMs);
-  const [row] = await db
-    .select({ count: sql<number>`count(*)::int` })
+  const now = Date.now();
+  const since = new Date(now - windowMs);
+  const rows = await db
+    .select({ createdAt: createdAtColumn })
     .from(table)
-    .where(and(eq(userColumn, userId), gte(createdAtColumn, since)));
-  const count = row?.count || 0;
+    .where(and(eq(userColumn, userId), gte(createdAtColumn, since)))
+    .orderBy(desc(createdAtColumn))
+    .limit(max);
+
+  const count = rows.length;
+  const oldest = rows[count - 1]?.createdAt;
+  const retryAfterSeconds =
+    oldest instanceof Date
+      ? Math.max(1, Math.ceil((oldest.getTime() + windowMs - now) / 1000))
+      : Math.max(1, Math.ceil(windowMs / 1000));
+
   return {
     allowed: count < max,
-    retryAfterSeconds: Math.max(1, Math.ceil(windowMs / 1000)),
+    retryAfterSeconds,
+    remaining: count < max ? Math.max(0, max - count) : 0,
+  };
+}
+
+export function checkInMemoryRateLimit({ key, windowMs, max }: InMemoryRateLimitCheck) {
+  const now = Date.now();
+  const entry = memoryRateStore.get(key);
+  if (!entry || now >= entry.resetAt) {
+    const resetAt = now + windowMs;
+    memoryRateStore.set(key, { count: 1, resetAt });
+    return {
+      allowed: true,
+      retryAfterSeconds: Math.max(1, Math.ceil(windowMs / 1000)),
+      remaining: Math.max(0, max - 1),
+    };
+  }
+
+  if (entry.count >= max) {
+    return {
+      allowed: false,
+      retryAfterSeconds: Math.max(1, Math.ceil((entry.resetAt - now) / 1000)),
+      remaining: 0,
+    };
+  }
+
+  entry.count += 1;
+  memoryRateStore.set(key, entry);
+  return {
+    allowed: true,
+    retryAfterSeconds: Math.max(1, Math.ceil((entry.resetAt - now) / 1000)),
+    remaining: Math.max(0, max - entry.count),
   };
 }


### PR DESCRIPTION
@codex\n\n## Summary\n- Improve DB-based rate limiter Retry-After accuracy\n- Add per-user rate limits for toggle endpoints (follow/like/bookmark/helpful)\n- Add Playwright E2E check for 429 on repeated post likes\n\n## Validation\n- npm run lint\n- npm run type-check\n- SKIP_SITEMAP_DB=true npm run build\n- npm run test:e2e